### PR TITLE
V0 3 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,5 @@ If playing on a new save file, you will still need to get to the end of each lev
 - `showTalismanCount` Prints how many Summer Forest Talisman items and how many Autumn Plains Talisman items the player has received.
 - `useQuietHints` Suppresses hints for found locations to make the client easier to read. On by default.
 - `useVerboseHints` Include found locations in hint lists. Due to Archipelago Server limitations, only applies to hints requested after this change.
+- `showUnlockedLevels` Show which levels the player has unlocked in open world mode.
+- `showGoal` Show what your completion goal is.

--- a/apworld/spyro2/Items.py
+++ b/apworld/spyro2/Items.py
@@ -16,7 +16,8 @@ class Spyro2ItemCategory(IntEnum):
     TOKEN = 7,
     ABILITY = 8,
     GEM = 9,
-    GEMSANITY_PARTIAL = 10
+    GEMSANITY_PARTIAL = 10,
+    LEVEL_UNLOCK = 11
 
 
 class Spyro2ItemData(NamedTuple):
@@ -83,6 +84,29 @@ _all_items = [Spyro2ItemData(row[0], row[1], row[2]) for row in [
     ("Moneybags Unlock - Shady Oasis Portal", 3009, Spyro2ItemCategory.MONEYBAGS),
     ("Moneybags Unlock - Icy Speedway Portal", 3010, Spyro2ItemCategory.MONEYBAGS),
     ("Moneybags Unlock - Canyon Speedway Portal", 3011, Spyro2ItemCategory.MONEYBAGS),
+    ("Colossus Unlock", 3012, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Idol Springs Unlock", 3013, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Hurricos Unlock", 3014, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Aquaria Towers Unlock", 3015, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Sunny Beach Unlock", 3016, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Ocean Speedway Unlock", 3017, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Skelos Badlands Unlock", 3018, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Crystal Glacier Unlock", 3019, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Breeze Harbor Unlock", 3020, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Zephyr Unlock", 3021, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Metro Speedway Unlock", 3022, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Scorch Unlock", 3023, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Shady Oasis Unlock", 3024, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Magma Cone Unlock", 3025, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Fracture Hills Unlock", 3026, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Icy Speedway Unlock", 3027, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Mystic Marsh Unlock", 3028, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Cloud Temples Unlock", 3029, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Canyon Speedway Unlock", 3030, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Robotica Farms Unlock", 3031, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Metropolis Unlock", 3032, Spyro2ItemCategory.LEVEL_UNLOCK),
+    ("Dragon Shores Unlock", 3033, Spyro2ItemCategory.LEVEL_UNLOCK),
+
 
     ("Glimmer Red Gem", 4000, Spyro2ItemCategory.GEM),
     ("Glimmer Green Gem", 4001, Spyro2ItemCategory.GEM),
@@ -218,9 +242,10 @@ item_descriptions = {}
 item_dictionary = {item_data.name: item_data for item_data in _all_items}
 
 
-def BuildItemPool(multiworld, count, options):
+def BuildItemPool(world, count, options):
     item_pool = []
     included_itemcount = 0
+    multiworld = world.multiworld
 
     if options.guaranteed_items.value:
         for item_name in options.guaranteed_items.value:
@@ -228,10 +253,44 @@ def BuildItemPool(multiworld, count, options):
             item_pool.append(item)
             included_itemcount = included_itemcount + 1
     remaining_count = count - included_itemcount
-    for i in range(6):
-        item_pool.append(item_dictionary["Summer Forest Talisman"])
-    for i in range(8):
-        item_pool.append(item_dictionary["Autumn Plains Talisman"])
+    if options.enable_open_world:
+        level_unlocks = [
+            item_dictionary["Colossus Unlock"],
+            item_dictionary["Idol Springs Unlock"],
+            item_dictionary["Hurricos Unlock"],
+            item_dictionary["Aquaria Towers Unlock"],
+            item_dictionary["Sunny Beach Unlock"],
+            item_dictionary["Ocean Speedway Unlock"],
+            item_dictionary["Skelos Badlands Unlock"],
+            item_dictionary["Crystal Glacier Unlock"],
+            item_dictionary["Breeze Harbor Unlock"],
+            item_dictionary["Zephyr Unlock"],
+            item_dictionary["Metro Speedway Unlock"],
+            item_dictionary["Scorch Unlock"],
+            item_dictionary["Shady Oasis Unlock"],
+            item_dictionary["Magma Cone Unlock"],
+            item_dictionary["Fracture Hills Unlock"],
+            item_dictionary["Icy Speedway Unlock"],
+            item_dictionary["Mystic Marsh Unlock"],
+            item_dictionary["Cloud Temples Unlock"],
+            item_dictionary["Canyon Speedway Unlock"],
+            item_dictionary["Robotica Farms Unlock"],
+            item_dictionary["Metropolis Unlock"],
+            item_dictionary["Dragon Shores Unlock"]
+        ]
+        starting_unlocks = multiworld.random.sample(level_unlocks, k=4)
+        starting_unlocks = [lvl.name for lvl in starting_unlocks]
+        for level in level_unlocks:
+            if level.name in starting_unlocks:
+                multiworld.push_precollected(world.create_item(level.name))
+            else:
+                item_pool.append(level)
+        remaining_count = remaining_count - 4
+    else:
+        for i in range(6):
+            item_pool.append(item_dictionary["Summer Forest Talisman"])
+        for i in range(8):
+            item_pool.append(item_dictionary["Autumn Plains Talisman"])
     for i in range(64):
         item_pool.append(item_dictionary["Orb"])
     remaining_count = remaining_count - 78

--- a/apworld/spyro2/Items.py
+++ b/apworld/spyro2/Items.py
@@ -278,37 +278,45 @@ def BuildItemPool(world, count, options):
             item_dictionary["Metropolis Unlock"],
             item_dictionary["Dragon Shores Unlock"]
         ]
-        starting_unlocks = multiworld.random.sample(level_unlocks, k=4)
+        starting_unlocks = multiworld.random.sample(level_unlocks, k=world.options.open_world_level_unlocks.value)
         starting_unlocks = [lvl.name for lvl in starting_unlocks]
         for level in level_unlocks:
             if level.name in starting_unlocks:
                 multiworld.push_precollected(world.create_item(level.name))
             else:
                 item_pool.append(level)
-        remaining_count = remaining_count - 4
+        remaining_count = remaining_count - (22 - world.options.open_world_level_unlocks.value)
     else:
         for i in range(6):
             item_pool.append(item_dictionary["Summer Forest Talisman"])
         for i in range(8):
             item_pool.append(item_dictionary["Autumn Plains Talisman"])
+        remaining_count = remaining_count - 14
     for i in range(64):
         item_pool.append(item_dictionary["Orb"])
-    remaining_count = remaining_count - 78
+    remaining_count = remaining_count - 64
+
+    if world.options.enable_open_world.value and world.options.open_world_ability_and_warp_unlocks.value:
+        multiworld.push_precollected(world.create_item("Moneybags Unlock - Swim"))
+        multiworld.push_precollected(world.create_item("Moneybags Unlock - Climb"))
+        multiworld.push_precollected(world.create_item("Moneybags Unlock - Headbash"))
 
     if options.moneybags_settings.value == MoneybagsOptions.MONEYBAGSSANITY:
         item_pool.append(item_dictionary["Moneybags Unlock - Crystal Glacier Bridge"])
         item_pool.append(item_dictionary["Moneybags Unlock - Aquaria Towers Submarine"])
         item_pool.append(item_dictionary["Moneybags Unlock - Magma Cone Elevator"])
         # item_pool.append(item_dictionary["Moneybags Unlock - Glimmer Bridge"])
-        item_pool.append(item_dictionary["Moneybags Unlock - Swim"])
-        item_pool.append(item_dictionary["Moneybags Unlock - Climb"])
-        item_pool.append(item_dictionary["Moneybags Unlock - Headbash"])
         item_pool.append(item_dictionary["Moneybags Unlock - Door to Aquaria Towers"])
         item_pool.append(item_dictionary["Moneybags Unlock - Zephyr Portal"])
         item_pool.append(item_dictionary["Moneybags Unlock - Shady Oasis Portal"])
         item_pool.append(item_dictionary["Moneybags Unlock - Icy Speedway Portal"])
         item_pool.append(item_dictionary["Moneybags Unlock - Canyon Speedway Portal"])
-        remaining_count = remaining_count - 11
+        remaining_count = remaining_count - 8
+        if not world.options.enable_open_world.value or not world.options.open_world_ability_and_warp_unlocks.value:
+            item_pool.append(item_dictionary["Moneybags Unlock - Swim"])
+            item_pool.append(item_dictionary["Moneybags Unlock - Climb"])
+            item_pool.append(item_dictionary["Moneybags Unlock - Headbash"])
+            remaining_count = remaining_count - 3
 
     if options.double_jump_ability.value == AbilityOptions.IN_POOL:
         item_pool.append(item_dictionary["Double Jump Ability"])

--- a/apworld/spyro2/Locations.py
+++ b/apworld/spyro2/Locations.py
@@ -18,7 +18,8 @@ class Spyro2LocationCategory(IntEnum):
     SHORES_TOKEN = 10,
     MONEYBAGS = 11,
     LIFE_BOTTLE = 12,
-    GEM = 13
+    GEM = 13,
+    SPIRIT_PARTICLE = 14
 
 
 class Spyro2LocationData(NamedTuple):
@@ -670,6 +671,11 @@ for i in range(41):
 for i in range(8):
     metropolis_gems += [Spyro2LocationData(f"Metropolis: Gem {i + 119}", "Metropolis Gold Gem", Spyro2LocationCategory.GEM)]
 location_tables["Metropolis"] = location_tables["Metropolis"] + metropolis_gems
+
+# To ensure backwards compatibility, do not move gem location IDs.
+for level in location_tables.keys():
+    if level not in ["Summer Forest", "Ocean Speedway", "Crush's Dungeon", "Autumn Plains", "Metro Speedway", "Icy Speedway", "Gulp's Overlook", "Winter Tundra", "Canyon Speedway", "Dragon Shores", "Ripto's Arena", "Inventory"]:
+        location_tables[level] = location_tables[level] + [Spyro2LocationData(f"{level}: All Spirit Particles", "Filler", Spyro2LocationCategory.SPIRIT_PARTICLE)]
 
 location_dictionary: Dict[str, Spyro2LocationData] = {}
 for location_table in location_tables.values():

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -34,21 +34,30 @@ class AbilityOptions():
     VANILLA = 0
     IN_POOL = 1
     OFF = 2
+    START_WITH = 3
 
 class LogicTrickOptions():
     OFF = 0
     ON_WITH_DOUBLE_JUMP = 1
     ALWAYS_ON = 2
 
+class PortalTextColorOptions():
+    DEFAULT = 0
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+    PINK = 4
+    WHITE = 5
+
 
 class GoalOption(Choice):
     """Lets the user choose the completion goal.  Regardless of choice, the door to Ripto requires 40 orbs to open.
     Unless you are using glitches to enter boss fights, the first three goals should be equivalent.
     Ripto - Beat Ripto. The goal triggers during the ensuing cutscene.
-    14 Talisman - Collect 6 Summer Forest Talismans and 8 Autumn Plains Talismans and beat Ripto.
+    14 Talisman - Collect 6 Summer Forest Talismans and 8 Autumn Plains Talismans and beat Ripto. In Open World mode, defaults to Ripto.
     40 Orb - Collect 40 orbs and beat Ripto.
     64 Orb - Collect 64 orbs and beat Ripto.
-    100 Percent - Collect all talismans, orbs, and gems and beat Ripto.
+    100 Percent - Collect all talismans, orbs, and gems and beat Ripto. In Open World mode, no talismans are required.
     10 Tokens - Collect all 10 tokens in Dragon Shores.
     All Skillpoints - Collect all 16 skill points in the game. Excluded locations are still required for this goal.
     Epilogue - Unlock the full epilogue by collecting all 16 skill points and defeating Ripto. Excluded locations are still required for this goal."""
@@ -70,8 +79,22 @@ class GuaranteedItemsOption(ItemDict):
 class EnableOpenWorld(Toggle):
     """If on, Crush and Gulp do not require talismans.  Every level is unlocked by items.
     You start with Glimmer and 3 other unlocks."""
-    # TODO: Determine what this means for goals around talismans.
     display_name = "Enable Open World"
+
+class StartingLevelCount(Range):
+    """Determines how many level unlocks the player starts with.
+    The player always has access to Glimmer, homeworlds, and boss fights.
+    Starting with fewer than 8 unlocks requires you to add extra locations to the item pool.
+    NOTE: Only has an effect in Open World mode."""
+    display_name = "Open World Starting Level Unlocks"
+    range_start = 0
+    range_end = 22
+    default = 8
+
+class StartWithAbilitiesAndWarps(Toggle):
+    """If on in Open World mode, the player will start with swim, climb, headbash, and access to all 3 homeworlds.
+    NOTE: Open has an effect in Open World mode."""
+    display_name = "Open World Start With Abilities and Warps"
 
 class Enable25PctGemChecksOption(Toggle):
     """Adds checks for getting 25% of the gems in a level"""
@@ -110,6 +133,12 @@ class EnableSkillpointChecksOption(Toggle):
 class EnableLifeBottleChecksOption(Toggle):
     """Adds checks for getting life bottles"""
     display_name = "Enable Life Bottle Checks"
+
+class EnableSpiritParticleChecksOption(Toggle):
+    """Adds checks for getting all spirit particles in a level.
+    Some minigame enemies are counted as spirit particles, like Draclets in Crystal Glacier.
+    NOTE: Some enemies will only release spirit particles while the camera is on them."""
+    display_name = "Enable Spirit Particle Checks"
 
 class EnableGemsanityOption(Choice):
     """Adds checks for each individual gem.
@@ -231,12 +260,14 @@ class FireballAbility(Choice):
     This option affects how the game plays, not game logic.
     Vanilla - The fireball powerup in Dragon Shores behaves normally.
     In Pool - Adds Permanent Fireball to the item pool.  The Dragon Shores powerup does not work.
-    Off - Permanent Fireball is disabled. The Dragon Shores powerup does not work."""
+    Off - Permanent Fireball is disabled. The Dragon Shores powerup does not work.
+    Start With - You begin the game with fireball, as in New Game Plus."""
     display_name = "Permanent Fireball Ability"
     default = AbilityOptions.VANILLA
     option_vanilla = AbilityOptions.VANILLA
     option_in_pool = AbilityOptions.IN_POOL
     option_off = AbilityOptions.OFF
+    option_start_with = AbilityOptions.START_WITH
 
 # TODO: Support more granular tricks.
 class LogicCrushEarly(Choice):
@@ -275,12 +306,26 @@ class LogicRiptoEarly(Choice):
     option_on_with_double_jump = LogicTrickOptions.ON_WITH_DOUBLE_JUMP
     option_always_on = LogicTrickOptions.ALWAYS_ON
 
+class PortalAndGemCollectionColor(Choice):
+    """Changes the color of the number that appears when gems are collected,
+    as well as the text on portals."""
+    display_name = "Portal and Gem Collection Text Color"
+    default = PortalTextColorOptions.DEFAULT
+    option_default = PortalTextColorOptions.DEFAULT
+    option_red = PortalTextColorOptions.RED
+    option_green = PortalTextColorOptions.GREEN
+    option_blue = PortalTextColorOptions.BLUE
+    option_pink = PortalTextColorOptions.PINK
+    option_white = PortalTextColorOptions.WHITE
+
 
 @dataclass
 class Spyro2Option(PerGameCommonOptions):
     goal: GoalOption
     guaranteed_items: GuaranteedItemsOption
     enable_open_world: EnableOpenWorld
+    open_world_level_unlocks: StartingLevelCount
+    open_world_ability_and_warp_unlocks: StartWithAbilitiesAndWarps
     enable_25_pct_gem_checks: Enable25PctGemChecksOption
     enable_50_pct_gem_checks: Enable50PctGemChecksOption
     enable_75_pct_gem_checks: Enable75PctGemChecksOption
@@ -289,6 +334,7 @@ class Spyro2Option(PerGameCommonOptions):
     max_total_gem_checks: MaxTotalGemCheckOption
     enable_skillpoint_checks: EnableSkillpointChecksOption
     enable_life_bottle_checks: EnableLifeBottleChecksOption
+    enable_spirit_particle_checks: EnableSpiritParticleChecksOption
     enable_gemsanity: EnableGemsanityOption
     moneybags_settings: MoneybagsSettings
     enable_filler_extra_lives: EnableFillerExtraLives
@@ -307,6 +353,7 @@ class Spyro2Option(PerGameCommonOptions):
     logic_crush_early: LogicCrushEarly
     logic_gulp_early: LogicGulpEarly
     logic_ripto_early: LogicRiptoEarly
+    portal_gem_collection_color: PortalAndGemCollectionColor
 
 
 # Group logic/trick options together, especially for the local WebHost.
@@ -317,6 +364,13 @@ spyro_options_groups = [
             LogicCrushEarly,
             LogicGulpEarly,
             LogicRiptoEarly
+        ],
+        True
+    ),
+    OptionGroup(
+        "Cosmetics",
+        [
+            PortalAndGemCollectionColor
         ],
         True
     ),

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -67,6 +67,12 @@ class GuaranteedItemsOption(ItemDict):
     """Guarantees that the specified items will be in the item pool"""
     display_name = "Guaranteed Items"
 
+class EnableOpenWorld(Toggle):
+    """If on, Crush and Gulp do not require talismans.  Every level is unlocked by items.
+    You start with Glimmer and 3 other unlocks."""
+    # TODO: Determine what this means for goals around talismans.
+    display_name = "Enable Open World"
+
 class Enable25PctGemChecksOption(Toggle):
     """Adds checks for getting 25% of the gems in a level"""
     display_name = "Enable 25% Gem Checks"
@@ -274,6 +280,7 @@ class LogicRiptoEarly(Choice):
 class Spyro2Option(PerGameCommonOptions):
     goal: GoalOption
     guaranteed_items: GuaranteedItemsOption
+    enable_open_world: EnableOpenWorld
     enable_25_pct_gem_checks: Enable25PctGemChecksOption
     enable_50_pct_gem_checks: Enable50PctGemChecksOption
     enable_75_pct_gem_checks: Enable75PctGemChecksOption

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -111,15 +111,15 @@ class EnableGemsanityOption(Choice):
     all Moneybags prices will be set to 0 in game.
     Off: Individual gems are not checks.
     Partial: Every gem has a chance to be a check, but only 200 will be (chosen at random).  For every level with loose
-        gems (not speedways), 8 items giving 50 gems for that level will be added to the pool.
-    Full: All gems are checks.  Gem items will be shuffled only within your world.
-    FUll Global: All gems are checks.  Gem items can be anywhere."""
+        gems (not speedways), 8 items giving 50 gems for that level will be added to the pool."""
     display_name = "Enable Gemsanity"
     default = GemsanityOptions.OFF
     option_off = GemsanityOptions.OFF
     option_partial = GemsanityOptions.PARTIAL
-    option_full = GemsanityOptions.FULL
-    option_full_global = GemsanityOptions.FULL_GLOBAL
+    #option_full = GemsanityOptions.FULL
+    #option_full_global = GemsanityOptions.FULL_GLOBAL
+    #Full: All gems are checks.  Gem items will be shuffled only within your world.
+    #Full Global: All gems are checks.  Gem items can be anywhere.
 
 class MoneybagsSettings(Choice):
     """Determines settings for Moneybags unlocks.

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -600,7 +600,7 @@ class Spyro2World(World):
                 if len(self.chosen_gem_locations) == 0 or f"Summer Forest: Gem {gem - skipped_bits}" in self.chosen_gem_locations:
                     set_rule(
                         self.multiworld.get_location(f"Summer Forest: Gem {gem - skipped_bits}", self.player),
-                        lambda state: can_swim(self, state) and can_climb(self, state)
+                        lambda state: can_reach_summer_second_half(self, state) and can_climb(self, state)
                     )
             for gem in aquaria_gems:
                 skipped_bits = 0
@@ -787,7 +787,7 @@ class Spyro2World(World):
             set_indirect_rule(
                 self,
                 "Ocean Speedway",
-                lambda state: can_swim(self, state) and state.has("Orb", self.player, 3)
+                lambda state: can_reach_summer_second_half(self, state) and state.has("Orb", self.player, 3)
             )
 
         # Crush's Dungeon rules
@@ -1321,7 +1321,7 @@ class Spyro2World(World):
             set_indirect_rule(
                 self,
                 "Robotica Farms",
-                lambda state: can_headbash(self, state)
+                lambda state: can_reach_winter_second_half(self, state)
             )
 
         # Metropolis rules
@@ -1335,7 +1335,7 @@ class Spyro2World(World):
             set_indirect_rule(
                 self,
                 "Metropolis",
-                lambda state: can_headbash(self, state) and state.has("Orb", self.player, 25)
+                lambda state: can_reach_winter_second_half(self, state) and state.has("Orb", self.player, 25)
             )
 
         # Ripto's Arena rules

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -511,7 +511,7 @@ class Spyro2World(World):
             swim_gems = [1, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 49, 50, 51, 52, 53, 54, 68, 69, 74, 77, 78, 79, 80, 87, 88, 89, 90, 91, 92, 93, 116, 117, 118, 119, 120, 121, 138, 144, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158]
             climb_gems = [83, 84, 85, 86, 94, 102, 103, 104, 105, 106]
             aquaria_gems = [2, 3, 4, 5, 13, 21, 37, 43]
-            empty_bits = [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 97, 98, 99, 100, 108, 126, 127, 128]
+            empty_bits = [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 96, 97, 98, 99, 100, 108, 126, 127, 128]
             for gem in swim_gems:
                 skipped_bits = 0
                 for bit in empty_bits:
@@ -1267,6 +1267,12 @@ class Spyro2World(World):
                     locations_target.append(name_to_s2_code[location.item.name])
                 else:
                     locations_target.append(0)
+
+        gemsanity_locations = []
+        for loc in self.chosen_gem_locations:
+            loc_id = self.location_name_to_id[loc]
+            gemsanity_locations.append(loc_id)
+
         
 
         slot_data = {
@@ -1300,6 +1306,7 @@ class Spyro2World(World):
                 "logic_gulp_early": self.options.logic_gulp_early.value,
                 "logic_ripto_early": self.options.logic_ripto_early.value,
             },
+            "gemsanity_ids": gemsanity_locations,
             # "moneybags_prices": moneybags_prices,
             "seed": self.multiworld.seed_name,  # to verify the server's multiworld
             "slot": self.multiworld.player_name[self.player],  # to connect to server

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -217,7 +217,7 @@ class Spyro2World(World):
             elif location.category in self.enabled_location_categories:
                 itempoolSize += 1
 
-        foo = BuildItemPool(self.multiworld, itempoolSize, self.options)
+        foo = BuildItemPool(self, itempoolSize, self.options)
         for item in foo:
             itempool.append(self.create_item(item.name))
 
@@ -229,7 +229,7 @@ class Spyro2World(World):
         useful_categories = {}
 
         if name in key_item_names or \
-                item_dictionary[name].category in [Spyro2ItemCategory.TALISMAN, Spyro2ItemCategory.ORB, Spyro2ItemCategory.EVENT, Spyro2ItemCategory.MONEYBAGS, Spyro2ItemCategory.SKILLPOINT_GOAL, Spyro2ItemCategory.TOKEN, Spyro2ItemCategory.GEM, Spyro2ItemCategory.GEMSANITY_PARTIAL] or \
+                item_dictionary[name].category in [Spyro2ItemCategory.LEVEL_UNLOCK, Spyro2ItemCategory.TALISMAN, Spyro2ItemCategory.ORB, Spyro2ItemCategory.EVENT, Spyro2ItemCategory.MONEYBAGS, Spyro2ItemCategory.SKILLPOINT_GOAL, Spyro2ItemCategory.TOKEN, Spyro2ItemCategory.GEM, Spyro2ItemCategory.GEMSANITY_PARTIAL] or \
                 self.options.enable_progressive_sparx_logic.value and name == 'Progressive Sparx Health Upgrade':
             item_classification = ItemClassification.progression
         elif item_dictionary[name].category in useful_categories or \
@@ -282,21 +282,29 @@ class Spyro2World(World):
                         gems += 10
                 return gems
             elif level == 'Idol Springs':
+                if self.options.enable_open_world and not state.has("Idol Springs Unlock", self.player):
+                    return 0
                 # Probably 315, but gem RNG from the strong chest could impact this - remove those gems from logic.
                 gems = 298
                 if state.has("Moneybags Unlock - Swim", self.player):
                     gems += 102
                 return gems
             elif level == 'Colossus':
+                if self.options.enable_open_world and not state.has("Colossus Unlock", self.player):
+                    return 0
                 return 400
             elif level == 'Hurricos':
                 if not state.has("Moneybags Unlock - Swim", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Hurricos Unlock", self.player):
                     return 0
                 return 400
             elif level == 'Aquaria Towers':
                 if not state.has("Moneybags Unlock - Swim", self.player) or \
                         not state.has("Moneybags Unlock - Door to Aquaria Towers", self.player) or \
                         (self.options.enable_progressive_sparx_logic.value and not has_sparx_health(self, 1, state)):
+                    return 0
+                if self.options.enable_open_world and not state.has("Aquaria Towers Unlock", self.player):
                     return 0
                 # TODO: Allow for getting in without swim as a trick.
                 gems = 127
@@ -306,6 +314,8 @@ class Spyro2World(World):
             elif level == "Sunny Beach":
                 if not state.has("Moneybags Unlock - Swim", self.player):
                     return 0
+                if self.options.enable_open_world and not state.has("Sunny Beach Unlock", self.player):
+                    return 0
                 # TODO: Allow for getting in without swim.
                 gems = 380
                 if state.has("Moneybags Unlock - Climb", self.player):
@@ -313,6 +323,8 @@ class Spyro2World(World):
                 return gems
             elif level == "Ocean Speedway":
                 if not state.has("Moneybags Unlock - Swim", self.player) or not state.has("Orb", self.player, 3):
+                    return 0
+                if self.options.enable_open_world and not state.has("Ocean Speedway Unlock", self.player):
                     return 0
                 return 400
             elif level == "Autumn Plains":
@@ -332,9 +344,13 @@ class Spyro2World(World):
                 if not is_boss_defeated(self, "Crush", state) or \
                         (self.options.enable_progressive_sparx_logic.value and not has_sparx_health(self, 2, state)):
                     return 0
+                if self.options.enable_open_world and not state.has("Skelos Badlands Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Crystal Glacier":
                 if not is_boss_defeated(self, "Crush", state):
+                    return 0
+                if self.options.enable_open_world and not state.has("Crystal Glacier Unlock", self.player):
                     return 0
                 gems = 245
                 if state.has("Moneybags Unlock - Crystal Glacier Bridge", self.player):
@@ -343,10 +359,14 @@ class Spyro2World(World):
             elif level == "Breeze Harbor":
                 if not is_boss_defeated(self, "Crush", state):
                     return 0
+                if self.options.enable_open_world and not state.has("Breeze Harbor Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Zephyr":
                 if not is_boss_defeated(self, "Crush", state) or \
                         not state.has("Moneybags Unlock - Zephyr Portal", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Zephyr Unlock", self.player):
                     return 0
                 gems = 284
                 if state.has("Moneybags Unlock - Climb", self.player):
@@ -355,9 +375,13 @@ class Spyro2World(World):
             elif level == "Metro Speedway":
                 if not is_boss_defeated(self, "Crush", state) or not state.has("Orb", self.player, 6):
                     return 0
+                if self.options.enable_open_world and not state.has("Metro Speedway Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Scorch":
                 if not is_boss_defeated(self, "Crush", state) or not state.has("Moneybags Unlock - Climb", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Scorch Unlock", self.player):
                     return 0
                 return 400
             elif level == "Shady Oasis":
@@ -365,6 +389,8 @@ class Spyro2World(World):
                         not state.has("Moneybags Unlock - Climb", self.player) or \
                         not state.has("Orb", self.player, 8) or \
                         not state.has("Moneybags Unlock - Shady Oasis Portal", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Shady Oasis Unlock", self.player):
                     return 0
                 gems = 380
                 if state.has("Moneybags Unlock - Headbash", self.player):
@@ -375,6 +401,8 @@ class Spyro2World(World):
                         not state.has("Moneybags Unlock - Climb", self.player) or \
                         not state.has("Orb", self.player, 8):
                     return 0
+                if self.options.enable_open_world and not state.has("Magma Cone Unlock", self.player):
+                    return 0
                 gems = 295
                 if state.has("Moneybags Unlock - Magma Cone Elevator", self.player):
                     gems += 105
@@ -382,12 +410,16 @@ class Spyro2World(World):
             elif level == "Fracture Hills":
                 if not is_boss_defeated(self, "Crush", state) or not state.has("Moneybags Unlock - Climb", self.player):
                     return 0
+                if self.options.enable_open_world and not state.has("Fracture Hills Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Icy Speedway":
                 if not is_boss_defeated(self, "Crush", state) or \
                         not state.has("Moneybags Unlock - Climb", self.player) or \
                         not state.has("Orb", self.player, 8) or \
                         not state.has("Moneybags Unlock - Icy Speedway Portal", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Icy Speedway Unlock", self.player):
                     return 0
                 return 400
             elif level == "Winter Tundra":
@@ -402,9 +434,13 @@ class Spyro2World(World):
             elif level == "Mystic Marsh":
                 if not is_boss_defeated(self, "Gulp", state):
                     return 0
+                if self.options.enable_open_world and not state.has("Mystic Marsh Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Cloud Temples":
                 if not is_boss_defeated(self, "Gulp", state):
+                    return 0
+                if self.options.enable_open_world and not state.has("Cloud Temples Unlock", self.player):
                     return 0
                 gems = 375
                 if state.has("Moneybags Unlock - Headbash", self.player):
@@ -414,15 +450,21 @@ class Spyro2World(World):
                 if not is_boss_defeated(self, "Gulp", state) or \
                         not state.has("Moneybags Unlock - Canyon Speedway Portal", self.player):
                     return 0
+                if self.options.enable_open_world and not state.has("Canyon Speedway Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Robotica Farms":
                 if not is_boss_defeated(self, "Gulp", state) or \
                         not state.has("Moneybags Unlock - Headbash", self.player):
                     return 0
+                if self.options.enable_open_world and not state.has("Robotica Farms Unlock", self.player):
+                    return 0
                 return 400
             elif level == "Metropolis":
                 if not is_boss_defeated(self, "Gulp", state) or \
                         not state.has("Moneybags Unlock - Headbash", self.player):
+                    return 0
+                if self.options.enable_open_world and not state.has("Metropolis Unlock", self.player):
                     return 0
                 return 400
             return 0
@@ -572,6 +614,8 @@ class Spyro2World(World):
                     )
 
         # Idol Springs Rules
+        if self.options.enable_open_world:
+            set_indirect_rule(self, "Idol Springs", lambda state: state.has("Idol Springs Unlock", self.player))
         set_rule(
             self.multiworld.get_location("Idol Springs: Foreman Bud's puzzles", self.player),
             lambda state: state.has("Moneybags Unlock - Swim", self.player)
@@ -594,23 +638,42 @@ class Spyro2World(World):
                     )
 
         # Colossus Rules
+        if self.options.enable_open_world:
+            set_indirect_rule(self, "Colossus", lambda state: state.has("Colossus Unlock", self.player))
 
         # Hurricos Rules
-        set_indirect_rule(self, "Hurricos", lambda state: state.has("Moneybags Unlock - Swim", self.player))
+        if self.options.enable_open_world:
+            set_indirect_rule(self, "Hurricos", lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Hurricos Unlock", self.player))
+        else:
+            set_indirect_rule(self, "Hurricos", lambda state: state.has("Moneybags Unlock - Swim", self.player))
 
         # Aquaria Towers Rules
-        if self.options.enable_progressive_sparx_logic.value:
-            set_indirect_rule(
-                self,
-                "Aquaria Towers",
-                lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player) and has_sparx_health(self, 1, state)
-            )
+        if self.options.enable_open_world:
+            if self.options.enable_progressive_sparx_logic.value:
+                set_indirect_rule(
+                    self,
+                    "Aquaria Towers",
+                    lambda state: state.has("Aquaria Towers Unlock", self.player) and state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player) and has_sparx_health(self, 1, state)
+                )
+            else:
+                set_indirect_rule(
+                    self,
+                    "Aquaria Towers",
+                    lambda state: state.has("Aquaria Towers Unlock", self.player) and state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player)
+                )
         else:
-            set_indirect_rule(
-                self,
-                "Aquaria Towers",
-                lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player)
-            )
+            if self.options.enable_progressive_sparx_logic.value:
+                set_indirect_rule(
+                    self,
+                    "Aquaria Towers",
+                    lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player) and has_sparx_health(self, 1, state)
+                )
+            else:
+                set_indirect_rule(
+                    self,
+                    "Aquaria Towers",
+                    lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Moneybags Unlock - Door to Aquaria Towers", self.player)
+                )
         set_rule(
             self.multiworld.get_location("Aquaria Towers: Talisman", self.player),
             lambda state: state.has("Moneybags Unlock - Aquaria Towers Submarine", self.player)
@@ -655,7 +718,10 @@ class Spyro2World(World):
                     )
 
         # Sunny Beach rules
-        set_indirect_rule(self, "Sunny Beach", lambda state: state.has("Moneybags Unlock - Swim", self.player))
+        if self.options.enable_open_world:
+            set_indirect_rule(self, "Sunny Beach", lambda state: state.has("Sunny Beach Unlock", self.player) and state.has("Moneybags Unlock - Swim", self.player))
+        else:
+            set_indirect_rule(self, "Sunny Beach", lambda state: state.has("Moneybags Unlock - Swim", self.player))
         set_rule(
             self.multiworld.get_location("Sunny Beach: Turtle soup I", self.player),
             lambda state: state.has("Moneybags Unlock - Climb", self.player)
@@ -682,16 +748,23 @@ class Spyro2World(World):
                     )
 
         # Ocean Speedway rules
-        set_indirect_rule(
-            self,
-            "Ocean Speedway",
-            lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Orb", self.player, 3)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Ocean Speedway",
+                lambda state: state.has("Ocean Speedway Unlock", self.player) and state.has("Moneybags Unlock - Swim", self.player) and state.has("Orb", self.player, 3)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Ocean Speedway",
+                lambda state: state.has("Moneybags Unlock - Swim", self.player) and state.has("Orb", self.player, 3)
+            )
 
         # Crush's Dungeon rules
         # TODO: It is likely that the client implementation will make swim not required because Elora will warp
         #  the player. But this complicates the logic significantly.
-        if self.options.logic_crush_early.value == LogicTrickOptions.ALWAYS_ON or self.options.logic_crush_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
+        if self.options.enable_open_world or self.options.logic_crush_early.value == LogicTrickOptions.ALWAYS_ON or self.options.logic_crush_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
             if self.options.enable_progressive_sparx_logic.value:
                 set_indirect_rule(
                     self,
@@ -813,14 +886,34 @@ class Spyro2World(World):
                     )
 
         # Skelos Badlands rules
-        if self.options.enable_progressive_sparx_logic.value:
-            set_indirect_rule(
-                self,
-                "Skelos Badlands",
-                lambda state: has_sparx_health(self, 2, state)
-            )
+        if self.options.enable_open_world:
+            if self.options.enable_progressive_sparx_logic.value:
+                set_indirect_rule(
+                    self,
+                    "Skelos Badlands",
+                    lambda state: state.has("Skelos Badlands Unlock", self.player) and has_sparx_health(self, 2, state)
+                )
+            else:
+                set_indirect_rule(
+                    self,
+                    "Skelos Badlands",
+                    lambda state: state.has("Skelos Badlands Unlock", self.player)
+                )
+        else:
+            if self.options.enable_progressive_sparx_logic.value:
+                set_indirect_rule(
+                    self,
+                    "Skelos Badlands",
+                    lambda state: has_sparx_health(self, 2, state)
+                )
 
         # Crystal Glacier rules
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Crystal Glacier",
+                lambda state: state.has("Crystal Glacier Unlock", self.player)
+            )
         set_rule(
             self.multiworld.get_location("Crystal Glacier: Talisman", self.player),
             lambda state: state.has("Moneybags Unlock - Crystal Glacier Bridge", self.player)
@@ -856,13 +949,26 @@ class Spyro2World(World):
                     )
 
         # Breeze Harbor rules
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Breeze Harbor",
+                lambda state: state.has("Breeze Harbor Unlock", self.player)
+            )
 
         # Zephyr rules
-        set_indirect_rule(
-            self,
-            "Zephyr",
-            lambda state: state.has("Moneybags Unlock - Zephyr Portal", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Zephyr",
+                lambda state: state.has("Zephyr Unlock", self.player) and state.has("Moneybags Unlock - Zephyr Portal", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Zephyr",
+                lambda state: state.has("Moneybags Unlock - Zephyr Portal", self.player)
+            )
         set_rule(
             self.multiworld.get_location("Zephyr: Cowlek corral II", self.player),
             lambda state: state.has("Moneybags Unlock - Climb", self.player)
@@ -885,25 +991,46 @@ class Spyro2World(World):
                     )
 
         # Metro Speedway rules
-        set_indirect_rule(
-            self,
-            "Metro Speedway",
-            lambda state: state.has("Orb", self.player, 6)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Metro Speedway",
+                lambda state: state.has("Metro Speedway Unlock", self.player) and state.has("Orb", self.player, 6)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Metro Speedway",
+                lambda state: state.has("Orb", self.player, 6)
+            )
 
         # Scorch rules
-        set_indirect_rule(
-            self,
-            "Scorch",
-            lambda state: state.has("Moneybags Unlock - Climb", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Scorch",
+                lambda state: state.has("Scorch Unlock", self.player) and state.has("Moneybags Unlock - Climb", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Scorch",
+                lambda state: state.has("Moneybags Unlock - Climb", self.player)
+            )
 
         # Shady Oasis rules
-        set_indirect_rule(
-            self,
-            "Shady Oasis",
-            lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Shady Oasis Portal", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Shady Oasis",
+                lambda state: state.has("Shady Oasis Unlock", self.player) and state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Shady Oasis Portal", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Shady Oasis",
+                lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Shady Oasis Portal", self.player)
+            )
         set_rule(
             self.multiworld.get_location("Shady Oasis: Free Hippos", self.player),
             lambda state: state.has("Moneybags Unlock - Headbash", self.player)
@@ -926,11 +1053,18 @@ class Spyro2World(World):
                     )
 
         # Magma Cone rules
-        set_indirect_rule(
-            self,
-            "Magma Cone",
-            lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Magma Cone",
+                lambda state: state.has("Magma Cone Unlock", self.player) and state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Magma Cone",
+                lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8)
+            )
         set_rule(
             self.multiworld.get_location("Magma Cone: Talisman", self.player),
             lambda state: state.has("Moneybags Unlock - Magma Cone Elevator", self.player)
@@ -957,27 +1091,41 @@ class Spyro2World(World):
                     )
 
         # Fracture Hills rules
-        set_indirect_rule(
-            self,
-            "Fracture Hills",
-            lambda state: state.has("Moneybags Unlock - Climb", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Fracture Hills",
+                lambda state: state.has("Fracture Hills Unlock", self.player) and state.has("Moneybags Unlock - Climb", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Fracture Hills",
+                lambda state: state.has("Moneybags Unlock - Climb", self.player)
+            )
         set_rule(
             self.multiworld.get_location("Fracture Hills: Earthshaper bash", self.player),
             lambda state: state.has("Moneybags Unlock - Headbash", self.player)
         )
 
         # Icy Speedway rules
-        set_indirect_rule(
-            self,
-            "Icy Speedway",
-            lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Icy Speedway Portal", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Icy Speedway",
+                lambda state: state.has("Icy Speedway Unlock", self.player) and state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Icy Speedway Portal", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Icy Speedway",
+                lambda state: state.has("Moneybags Unlock - Climb", self.player) and state.has("Orb", self.player, 8) and state.has("Moneybags Unlock - Icy Speedway Portal", self.player)
+            )
 
         # Gulp's Overlook rules
         # TODO: The orb and climb requirements are likely not true because of Elora warping the player (or Gulp Skip).
         #  But this complicates logic substantially so ignore it for now.
-        if self.options.logic_gulp_early.value == LogicTrickOptions.ALWAYS_ON or self.options.logic_gulp_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
+        if self.options.enable_open_world or self.options.logic_gulp_early.value == LogicTrickOptions.ALWAYS_ON or self.options.logic_gulp_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
             if self.options.enable_progressive_sparx_logic.value:
                 set_indirect_rule(
                     self,
@@ -1062,13 +1210,26 @@ class Spyro2World(World):
                     )
 
         # Mystic Marsh rules
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Mystic Marsh",
+                lambda state: state.has("Mystic Marsh Unlock", self.player)
+            )
 
         # Cloud Temples rules
-        set_indirect_rule(
-            self,
-            "Cloud Temples",
-            lambda state: state.has("Orb", self.player, 15)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Cloud Temples",
+                lambda state: state.has("Cloud Temples Unlock", self.player) and state.has("Orb", self.player, 15)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Cloud Temples",
+                lambda state: state.has("Orb", self.player, 15)
+            )
         if Spyro2LocationCategory.GEM in self.enabled_location_categories:
             # Bits of the gems, not accounting for empty bits
             headbash_gems = [104, 105, 106, 107, 108]
@@ -1087,28 +1248,49 @@ class Spyro2World(World):
                     )
 
         # Canyon Speedway rules
-        set_indirect_rule(
-            self,
-            "Canyon Speedway",
-            lambda state: state.has("Moneybags Unlock - Canyon Speedway Portal", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Canyon Speedway",
+                lambda state: state.has("Canyon Speedway Unlock", self.player) and state.has("Moneybags Unlock - Canyon Speedway Portal", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Canyon Speedway",
+                lambda state: state.has("Moneybags Unlock - Canyon Speedway Portal", self.player)
+            )
 
         # Robotica Farms rules
-        set_indirect_rule(
-            self,
-            "Robotica Farms",
-            lambda state: state.has("Moneybags Unlock - Headbash", self.player)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Robotica Farms",
+                lambda state: state.has("Robotica Farms Unlock", self.player) and state.has("Moneybags Unlock - Headbash", self.player)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Robotica Farms",
+                lambda state: state.has("Moneybags Unlock - Headbash", self.player)
+            )
 
         # Metropolis rules
-        set_indirect_rule(
-            self,
-            "Metropolis",
-            lambda state: state.has("Moneybags Unlock - Headbash", self.player) and state.has("Orb", self.player, 25)
-        )
+        if self.options.enable_open_world:
+            set_indirect_rule(
+                self,
+                "Metropolis",
+                lambda state: state.has("Metropolis Unlock", self.player) and state.has("Moneybags Unlock - Headbash", self.player) and state.has("Orb", self.player, 25)
+            )
+        else:
+            set_indirect_rule(
+                self,
+                "Metropolis",
+                lambda state: state.has("Moneybags Unlock - Headbash", self.player) and state.has("Orb", self.player, 25)
+            )
 
         # Ripto's Arena rules
-        if self.options.logic_ripto_early.value == LogicTrickOptions.ALWAYS_ON  or self.options.logic_ripto_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
+        if self.options.logic_ripto_early.value == LogicTrickOptions.ALWAYS_ON or self.options.logic_ripto_early.value == LogicTrickOptions.ON_WITH_DOUBLE_JUMP and self.options.double_jump_ability.value == AbilityOptions.VANILLA:
             if self.options.enable_progressive_sparx_logic.value:
                 set_indirect_rule(
                     self,
@@ -1149,7 +1331,10 @@ class Spyro2World(World):
                 )
 
         # Dragon Shores rules
-        set_indirect_rule(self, "Dragon Shores", lambda state: is_boss_defeated(self, "Ripto", state))
+        if self.options.enable_open_world:
+            set_indirect_rule(self, "Dragon Shores", lambda state: state.has("Dragon Shores Unlock", self.player) and is_boss_defeated(self, "Ripto", state))
+        else:
+            set_indirect_rule(self, "Dragon Shores", lambda state: is_boss_defeated(self, "Ripto", state))
         if Spyro2LocationCategory.SHORES_TOKEN in self.enabled_location_categories:
             set_rule(
                 self.multiworld.get_location("Dragon Shores: Tunnel o' Love", self.player),
@@ -1279,6 +1464,7 @@ class Spyro2World(World):
             "options": {
                 "goal": self.options.goal.value,
                 "guaranteed_items": self.options.guaranteed_items.value,
+                "enable_open_world": self.options.enable_open_world.value,
                 "enable_25_pct_gem_checks": self.options.enable_25_pct_gem_checks.value,
                 "enable_50_pct_gem_checks": self.options.enable_50_pct_gem_checks.value,
                 "enable_75_pct_gem_checks": self.options.enable_75_pct_gem_checks.value,

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -622,7 +622,7 @@ class Spyro2World(World):
         )
         if Spyro2LocationCategory.GEM in self.enabled_location_categories:
             # Bits of the gems, not accounting for empty bits
-            climb_gems = [14, 15, 16, 17, 18, 19, 21, 22, 23, 55]
+            climb_gems = [110, 111, 112, 113, 114, 115, 117, 118, 119, 151]
             empty_bits = [1, 2, 3, 4, 5, 6, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 152]
             for gem in climb_gems:
                 skipped_bits = 0

--- a/apworld/spyro2/docs/en_Spyro 2.md
+++ b/apworld/spyro2/docs/en_Spyro 2.md
@@ -63,3 +63,5 @@ If playing on a new save file, you will still need to get to the end of each lev
 - `showTalismanCount` Prints how many Summer Forest Talisman items and how many Autumn Plains Talisman items the player has received.
 - `useQuietHints` Suppresses hints for found locations to make the client easier to read. On by default.
 - `useVerboseHints` Include found locations in hint lists. Due to Archipelago Server limitations, only applies to hints requested after this change.
+- `showUnlockedLevels` Show which levels the player has unlocked in open world mode.
+- `showGoal` Show what your completion goal is.

--- a/source/S2AP.Desktop/S2AP.Desktop.csproj
+++ b/source/S2AP.Desktop/S2AP.Desktop.csproj
@@ -15,9 +15,10 @@
     <!-- App Identifier -->
     <ApplicationId>com.uroogla.s2ap</ApplicationId>
     <!-- Versions -->
-    <ApplicationDisplayVersion>0.2.0</ApplicationDisplayVersion>
-    <ApplicationVersion>0.5.2</ApplicationVersion>
-    <Version>0.2.0</Version>
+    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
+    <ApplicationVersion>0.3.0</ApplicationVersion>
+    <Version>0.3.0</Version>
+	<ApplicationManifest>app.manifest</ApplicationManifest>
     <!-- Single File Publishing Properties -->
     <PublishSingleFile>true</PublishSingleFile>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>

--- a/source/S2AP.Desktop/app.manifest
+++ b/source/S2AP.Desktop/app.manifest
@@ -4,6 +4,13 @@
        Don't remove it as it might cause problems with window transparency and embeded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
   <assemblyIdentity version="1.0.0.0" name="AvaloniaTest.Desktop"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -15,6 +15,7 @@ namespace S2AP
         public const uint ResetCheckAddress = 0x00066f14;
         public const uint PlayerLives = 0x0006712c;
         public const uint PlayerHealth = 0x0006a248;
+        public const uint SpiritParticlesAddress = 0x00066fb0;
 
         public const uint TotalGemAddress = 0x000670cc; // 0x00067660 is the HUD display; may need to be edited if this value is modified.
         public const uint LevelGemsAddress = 0x0006ac04; // One entire word per level, including boss levels.
@@ -46,6 +47,9 @@ namespace S2AP
         public const uint SpyroHeight = 0x0698c5;
         public const uint SpyroLength = 0x0698c9;
         public const uint SpyroColorAddress = 0x0698cc;
+        public const uint PortalTextRed = 0x00064468;
+        public const uint PortalTextGreen = 0x00064469;
+        public const uint PortalTextBlue = 0x0006446a;
 
         public const uint PermanentFireballAddress = 0x000698bb;
         public const uint DoubleJumpAddress1 = 0x00035ba8;
@@ -135,7 +139,9 @@ namespace S2AP
         public const uint WinterPortalBlock = 0x000cf28c;
 
         public const uint CrushGuidebookUnlock = 0x0006B08C;
+        public const uint AutumnGuidebookUnlock = 0x0006B08D;
         public const uint GulpGuidebookUnlock = 0x0006B098;
+        public const uint WinterGuidebookUnlock = 0x0006B099;
 
         public const uint IdolPortalAddress = 0x001757C8;
         public const uint ColossusPortalAddress = 0x00175668;
@@ -143,5 +149,28 @@ namespace S2AP
         public const uint AquariaPortalAddress = 0x00175770;
         public const uint SunnyPortalAddress = 0x00175718;
         public const uint OceanPortalAddress = 0x00179A20;
+
+        public const uint IdolNameAddress = 0x000106d0;
+        public const uint ColossusNameAddress = 0x000106c4;
+        public const uint HurricosNameAddress = 0x000106b8;
+        public const uint AquariaNameAddress = 0x000106a8;
+        public const uint SunnyNameAddress = 0x0001069c;
+        public const uint OceanNameAddress = 0x0001068c;
+        public const uint SkelosNameAddress = 0x0001065c;
+        public const uint CrystalNameAddress = 0x0001064c;
+        public const uint BreezeNameAddress = 0x0001063c;
+        public const uint ZephyrNameAddress = 0x00066e98;
+        public const uint MetroNameAddress = 0x0001062c;
+        public const uint ScorchNameAddress = 0x00066e90;
+        public const uint ShadyNameAddress = 0x00010620;
+        public const uint MagmaNameAddress = 0x00010614;
+        public const uint FractureNameAddress = 0x00010604;
+        public const uint IcyNameAddress = 0x000105f4;
+        public const uint MysticNameAddress = 0x000105c4;
+        public const uint CloudNameAddress = 0x000105b4;
+        public const uint CanyonNameAddress = 0x000105a4;
+        public const uint RoboticaNameAddress = 0x00010594;
+        public const uint MetropolisNameAddress = 0x00010588;
+        public const uint ShoresNameAddress = 0x00010578;
     }
 }

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -129,5 +129,19 @@ namespace S2AP
         public const uint localGemRespawnFixAddress = 0x0001d380;
         public const uint localGemLoadFixAddress = 0x00076B98;
         public const uint globalGemLoadFixAddress = 0x00076BA0;
+
+        public const uint SummerPortalBlock = 0x000e2d34;
+        public const uint AutumnPortalBlock = 0x000f5330;
+        public const uint WinterPortalBlock = 0x000cf28c;
+
+        public const uint CrushGuidebookUnlock = 0x0006B08C;
+        public const uint GulpGuidebookUnlock = 0x0006B098;
+
+        public const uint IdolPortalAddress = 0x001757C8;
+        public const uint ColossusPortalAddress = 0x00175668;
+        public const uint HurricosPortalAddress = 0x001756c0;
+        public const uint AquariaPortalAddress = 0x00175770;
+        public const uint SunnyPortalAddress = 0x00175718;
+        public const uint OceanPortalAddress = 0x00179A20;
     }
 }

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -9,6 +9,7 @@ using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Packets;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Platform;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.OpenGL;
@@ -104,6 +105,9 @@ public partial class App : Application
             case "useVerboseHints":
                 Log.Logger.Information("Hints for found locations will be displayed.  Type 'useQuietHints' to show them.");
                 _useQuietHints = false;
+                break;
+            case "showUnlockedLevels":
+                showUnlockedLevels();
                 break;
         }
     }
@@ -314,8 +318,6 @@ public partial class App : Application
                     UnlockMoneybags(Addresses.CrystalBridgeUnlock);
                 }
                 break;
-            // v0.1.0 had a typo, so support both for backwards compatibility.
-            case "Moneybags Unlock - Aquaria Tower Submarine":
             case "Moneybags Unlock - Aquaria Towers Submarine":
                 if (_moneybagsOption == MoneybagsOptions.Moneybagssanity)
                 {
@@ -389,7 +391,26 @@ public partial class App : Application
                     CalculateCurrentGems();
                     CheckGoalCondition();
                 }
+                else if (args.Item.Name.EndsWith(" Unlock"))
+                {
+                    // Unlock effects managed by HandleAbilities().
+                    showUnlockedLevels();
+                }
                 break;
+        }
+    }
+    private void showUnlockedLevels()
+    {
+        List<Item> unlockedLevels = (Client.GameState?.ReceivedItems.Where(x => x.Name.EndsWith(" Unlock")).ToList() ?? new List<Item>());
+        if (unlockedLevels.Count > 0)
+        {
+            string unlockedLevelsString = "You have unlocked: ";
+            foreach (Item unlockedLevel in unlockedLevels)
+            {
+                unlockedLevelsString += (unlockedLevel.Name.Split(" Unlock")[0] + "; ");
+            }
+            unlockedLevelsString = unlockedLevelsString.Substring(0, unlockedLevelsString.Length - 2);
+            Log.Logger.Information(unlockedLevelsString);
         }
     }
     private static async void HandleAbilities(object source, ElapsedEventArgs e)
@@ -439,6 +460,116 @@ public partial class App : Application
             Memory.Write(Addresses.localGemRespawnFixAddress, 0);
             //Memory.Write(Addresses.localGemLoadFixAddress, 0);
             //Memory.Write(Addresses.globalGemLoadFixAddress, 0);
+        }
+        int openWorldOption = int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString());
+        if (openWorldOption != 0)
+        {
+            LevelInGameIDs currentLevel = (LevelInGameIDs)Memory.ReadByte(Addresses.CurrentLevelAddress);
+
+            if (currentLevel == LevelInGameIDs.SummerForest)
+            {
+                bool isIdolUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Idol Springs Unlock")).Count() ?? 0) > 0;
+                bool isColossusUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Colossus Unlock")).Count() ?? 0) > 0;
+                bool isHurricosUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Hurricos Unlock")).Count() ?? 0) > 0;
+                bool isAquariaUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Aquaria Towers Unlock")).Count() ?? 0) > 0;
+                bool isSunnyUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Sunny Beach Unlock")).Count() ?? 0) > 0;
+                bool isOceanUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Ocean Speedway Unlock")).Count() ?? 0) > 0;
+                bool[] summerUnlocks = [
+                    isIdolUnlocked,
+                    isColossusUnlocked,
+                    isHurricosUnlocked,
+                    isAquariaUnlocked,
+                    isSunnyUnlocked,
+                    isOceanUnlocked
+                ];
+                // Glimmer is always unlocked.
+                uint portalAddress = Addresses.SummerPortalBlock + 8;
+                foreach (bool isUnlocked in summerUnlocks)
+                {
+                    if (isUnlocked)
+                    {
+                        Memory.Write(portalAddress, 6);
+                    } else
+                    {
+                        Memory.Write(portalAddress, 0);
+                    }
+                    portalAddress += 8;
+                }
+                /*Memory.Write(Addresses.IdolPortalAddress + 0x48, isIdolUnlocked ? 0x01100100 : 0x00100001);
+                Memory.Write(Addresses.ColossusPortalAddress + 0x48, isColossusUnlocked ? 0x01100100 : 0x00100001);
+                Memory.Write(Addresses.HurricosPortalAddress + 0x48, isHurricosUnlocked ? 0x01100100 : 0x00100001);
+                Memory.Write(Addresses.AquariaPortalAddress + 0x48, isAquariaUnlocked ? 0x01100100 : 0x00100001);
+                Memory.Write(Addresses.SunnyPortalAddress + 0x48, isSunnyUnlocked ? 0x01100100 : 0x00100001);
+                Memory.Write(Addresses.OceanPortalAddress + 0x48, isOceanUnlocked ? 0x01100100 : 0x00100001);*/
+            }
+            else if (currentLevel == LevelInGameIDs.AutumnPlains)
+            {
+                bool isSkelosUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Skelos Badlands Unlock")).Count() ?? 0) > 0;
+                bool isCrystalUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Crystal Glacier Unlock")).Count() ?? 0) > 0;
+                bool isBreezeUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Breeze Harbor Unlock")).Count() ?? 0) > 0;
+                bool isZephyrUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Zephyr Unlock")).Count() ?? 0) > 0;
+                bool isMetroUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Metro Speedway Unlock")).Count() ?? 0) > 0;
+                bool isScorchUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Scorch Unlock")).Count() ?? 0) > 0;
+                bool isShadyUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Shady Oasis Unlock")).Count() ?? 0) > 0;
+                bool isMagmaUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Magma Cone Unlock")).Count() ?? 0) > 0;
+                bool isFractureUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Fracture Hills Unlock")).Count() ?? 0) > 0;
+                bool isIcyUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Icy Speedway Unlock")).Count() ?? 0) > 0;
+                bool[] autumnUnlocks = [
+                    isSkelosUnlocked,
+                    isCrystalUnlocked,
+                    isBreezeUnlocked,
+                    isZephyrUnlocked,
+                    isMetroUnlocked,
+                    isScorchUnlocked,
+                    isShadyUnlocked,
+                    isMagmaUnlocked,
+                    isFractureUnlocked,
+                    isIcyUnlocked
+                ];
+                uint portalAddress = Addresses.AutumnPortalBlock;
+                foreach (bool isUnlocked in autumnUnlocks)
+                {
+                    if (isUnlocked)
+                    {
+                        Memory.Write(portalAddress, 6);
+                    }
+                    else
+                    {
+                        Memory.Write(portalAddress, 0);
+                    }
+                    portalAddress += 8;
+                }
+            }
+            else if (currentLevel == LevelInGameIDs.WinterTundra)
+            {
+                bool isMysticUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Mystic Marsh Unlock")).Count() ?? 0) > 0;
+                bool isCloudUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Cloud Temples Unlock")).Count() ?? 0) > 0;
+                bool isCanyonUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Canyon Speedway Unlock")).Count() ?? 0) > 0;
+                bool isRoboticaUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Robotica Farms Unlock")).Count() ?? 0) > 0;
+                bool isMetropolisUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Metropolis Unlock")).Count() ?? 0) > 0;
+                bool isDragonShoresUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Dragon Shores Unlock")).Count() ?? 0) > 0;
+                bool[] winterUnlocks = [
+                    isMysticUnlocked,
+                    isCloudUnlocked,
+                    isCanyonUnlocked,
+                    isRoboticaUnlocked,
+                    isMetropolisUnlocked,
+                    isDragonShoresUnlocked
+                ];
+                uint portalAddress = Addresses.WinterPortalBlock;
+                foreach (bool isUnlocked in winterUnlocks)
+                {
+                    if (isUnlocked)
+                    {
+                        Memory.Write(portalAddress, 6);
+                    }
+                    else
+                    {
+                        Memory.Write(portalAddress, 0);
+                    }
+                    portalAddress += 8;
+                }
+            }
         }
     }
     private static async void HandleMaxSparxHealth(object source, ElapsedEventArgs e)
@@ -550,6 +681,14 @@ public partial class App : Application
                     Memory.Write(unlockAddress, 65536);
                 }
             }
+        }
+        int openWorldOption = int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString());
+        Log.Logger.Information($"{openWorldOption} {Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString()}");
+        if (openWorldOption != 0)
+        {
+            Memory.WriteByte(Addresses.CrushGuidebookUnlock, 1);
+            Memory.WriteByte(Addresses.GulpGuidebookUnlock, 1);
+            // TODO: Determine whether or not to unlock Autumn and Winter.
         }
         _loadGameTimer.Enabled = false;
     }

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -43,6 +43,7 @@ public partial class App : Application
     private static Timer _abilitiesTimer { get; set; }
     private static Timer _cosmeticsTimer { get; set; }
     private static MoneybagsOptions _moneybagsOption { get; set; }
+    private static PortalTextColor _portalTextColor { get; set; }
     private static bool _destructiveMode { get; set; }
     public override void Initialize()
     {
@@ -335,19 +336,31 @@ public partial class App : Application
                 }
                 break;
             case "Moneybags Unlock - Swim":
-                if (_moneybagsOption == MoneybagsOptions.Moneybagssanity)
+                if (
+                    _moneybagsOption == MoneybagsOptions.Moneybagssanity ||
+                    int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString()) == 1 &&
+                    int.Parse(Client.Options?.GetValueOrDefault("open_world_ability_and_warp_unlocks", "0").ToString()) == 1
+                )
                 {
                     UnlockMoneybags(Addresses.SwimUnlock);
                 }
                 break;
             case "Moneybags Unlock - Climb":
-                if (_moneybagsOption == MoneybagsOptions.Moneybagssanity)
+                if (
+                    _moneybagsOption == MoneybagsOptions.Moneybagssanity ||
+                    int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString()) == 1 &&
+                    int.Parse(Client.Options?.GetValueOrDefault("open_world_ability_and_warp_unlocks", "0").ToString()) == 1
+                )
                 {
                     UnlockMoneybags(Addresses.ClimbUnlock);
                 }
                 break;
             case "Moneybags Unlock - Headbash":
-                if (_moneybagsOption == MoneybagsOptions.Moneybagssanity)
+                if (
+                    _moneybagsOption == MoneybagsOptions.Moneybagssanity ||
+                    int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString()) == 1 &&
+                    int.Parse(Client.Options?.GetValueOrDefault("open_world_ability_and_warp_unlocks", "0").ToString()) == 1
+                )
                 {
                     UnlockMoneybags(Addresses.HeadbashUnlock);
                 }
@@ -397,7 +410,76 @@ public partial class App : Application
                 }
                 else if (args.Item.Name.EndsWith(" Unlock"))
                 {
-                    // Unlock effects managed by HandleAbilities().
+                    switch (args.Item.Name)
+                    {
+                        case "Idol Springs Unlock":
+                            WriteStringToMemory(Addresses.IdolNameAddress, Addresses.IdolNameAddress + 16, "Idol Springs", padWithSpaces: false);
+                            break;
+                        case "Colossus Unlock":
+                            WriteStringToMemory(Addresses.ColossusNameAddress, Addresses.ColossusNameAddress + 12, "Colossus", padWithSpaces: false);
+                            break;
+                        case "Hurricos Unlock":
+                            WriteStringToMemory(Addresses.HurricosNameAddress, Addresses.HurricosNameAddress + 12, "Hurricos", padWithSpaces: false);
+                            break;
+                        case "Aquaria Towers Unlock":
+                            WriteStringToMemory(Addresses.AquariaNameAddress, Addresses.AquariaNameAddress + 16, "Aquaria Towers", padWithSpaces: false);
+                            break;
+                        case "Sunny Beach Unlock":
+                            WriteStringToMemory(Addresses.SunnyNameAddress, Addresses.SunnyNameAddress + 12, "Sunny Beach", padWithSpaces: false);
+                            break;
+                        case "Ocean Speedway Unlock":
+                            WriteStringToMemory(Addresses.OceanNameAddress, Addresses.OceanNameAddress + 16, "Ocean Speedway", padWithSpaces: false);
+                            break;
+                        case "Skelos Badlands Unlock":
+                            WriteStringToMemory(Addresses.SkelosNameAddress, Addresses.SkelosNameAddress + 16, "Skelos Badlands", padWithSpaces: false);
+                            break;
+                        case "Crystal Glacier Unlock":
+                            WriteStringToMemory(Addresses.CrystalNameAddress, Addresses.CrystalNameAddress + 16, "Crystal Glacier", padWithSpaces: false);
+                            break;
+                        case "Breeze Harbor Unlock":
+                            WriteStringToMemory(Addresses.BreezeNameAddress, Addresses.BreezeNameAddress + 16, "Breeze Harbor", padWithSpaces: false);
+                            break;
+                        case "Zephyr Unlock":
+                            WriteStringToMemory(Addresses.ZephyrNameAddress, Addresses.ZephyrNameAddress + 8, "Zephyr", padWithSpaces: false);
+                            break;
+                        case "Metro Speedway Unlock":
+                            WriteStringToMemory(Addresses.MetroNameAddress, Addresses.MetroNameAddress + 16, "Metro Speedway", padWithSpaces: false);
+                            break;
+                        case "Scorch Unlock":
+                            WriteStringToMemory(Addresses.ScorchNameAddress, Addresses.ScorchNameAddress + 8, "Scorch", padWithSpaces: false);
+                            break;
+                        case "Shady Oasis Unlock":
+                            WriteStringToMemory(Addresses.ShadyNameAddress, Addresses.ShadyNameAddress + 12, "Shady Oasis", padWithSpaces: false);
+                            break;
+                        case "Magma Cone Unlock":
+                            WriteStringToMemory(Addresses.MagmaNameAddress, Addresses.MagmaNameAddress + 12, "Magma Cone", padWithSpaces: false);
+                            break;
+                        case "Fracture Hills Unlock":
+                            WriteStringToMemory(Addresses.FractureNameAddress, Addresses.FractureNameAddress + 16, "Fracture Hills", padWithSpaces: false);
+                            break;
+                        case "Icy Speedway Unlock":
+                            WriteStringToMemory(Addresses.IcyNameAddress, Addresses.IcyNameAddress + 16, "Icy Speedway", padWithSpaces: false);
+                            break;
+                        case "Mystic Marsh Unlock":
+                            WriteStringToMemory(Addresses.MysticNameAddress, Addresses.MysticNameAddress + 16, "Mystic Marsh", padWithSpaces: false);
+                            break;
+                        case "Cloud Temples Unlock":
+                            WriteStringToMemory(Addresses.CloudNameAddress, Addresses.CloudNameAddress + 16, "Cloud Temples", padWithSpaces: false);
+                            break;
+                        case "Canyon Speedway Unlock":
+                            WriteStringToMemory(Addresses.CanyonNameAddress, Addresses.CanyonNameAddress + 16, "Canyon Speedway", padWithSpaces: false);
+                            break;
+                        case "Robotica Farms Unlock":
+                            WriteStringToMemory(Addresses.RoboticaNameAddress, Addresses.RoboticaNameAddress + 16, "Robotica Farms", padWithSpaces: false);
+                            break;
+                        case "Metropolis Unlock":
+                            WriteStringToMemory(Addresses.MetropolisNameAddress, Addresses.MetropolisNameAddress + 12, "Metropolis", padWithSpaces: false);
+                            break;
+                        case "Dragon Shores Unlock":
+                            WriteStringToMemory(Addresses.ShoresNameAddress, Addresses.ShoresNameAddress + 16, "Dragon Shores", padWithSpaces: false);
+                            break;
+                    }
+                    // Other unlock effects managed by HandleAbilities().
                     showUnlockedLevels();
                 }
                 break;
@@ -406,20 +488,40 @@ public partial class App : Application
     private void showUnlockedLevels()
     {
         List<Item> unlockedLevels = (Client.GameState?.ReceivedItems.Where(x => x.Name.EndsWith(" Unlock")).ToList() ?? new List<Item>());
-        if (unlockedLevels.Count > 0)
+        if (unlockedLevels.Count >= int.Parse(Client.Options?.GetValueOrDefault("open_world_level_unlocks", "0").ToString()))
         {
-            string unlockedLevelsString = "You have unlocked: ";
+            Log.Logger.Information("You have unlocked: ");
+            string unlockedLevelsString = "";
+            int levelCount = 0;
             foreach (Item unlockedLevel in unlockedLevels)
             {
-                unlockedLevelsString += (unlockedLevel.Name.Split(" Unlock")[0] + "; ");
+                if (unlockedLevel.Name == "Dragon Shores Unlock")
+                {
+                    unlockedLevelsString += ("Shores" + "; ");
+                }
+                else
+                {
+                    string newLevel = unlockedLevel.Name.Split(" Unlock")[0].Split(" ")[0];
+                    unlockedLevelsString += (newLevel + "; ");
+                }
+                levelCount++;
+                // Print 6 per line so it is easier to read.
+                if (levelCount % 6 == 0)
+                {
+                    Log.Logger.Information(unlockedLevelsString.Substring(0, unlockedLevelsString.Length - 2));
+                    unlockedLevelsString = "";
+                }
             }
-            unlockedLevelsString = unlockedLevelsString.Substring(0, unlockedLevelsString.Length - 2);
-            Log.Logger.Information(unlockedLevelsString);
+            if (unlockedLevelsString.Length > 0)
+            {
+                unlockedLevelsString = unlockedLevelsString.Substring(0, unlockedLevelsString.Length - 2);
+                Log.Logger.Information(unlockedLevelsString);
+            }
         }
     }
     private static async void HandleAbilities(object source, ElapsedEventArgs e)
     {
-        if (!Helpers.IsInGame())
+        if (!Helpers.IsInGame() || Client.GameState == null || Client.CurrentSession == null)
         {
             return;
         }
@@ -444,7 +546,7 @@ public partial class App : Application
         {
             Memory.WriteByte(Addresses.PermanentFireballAddress, (byte)0);
         }
-        else if (fireballOption == AbilityOptions.InPool && hasFireballItem == 1)
+        else if (fireballOption == AbilityOptions.StartWith || fireballOption == AbilityOptions.InPool && hasFireballItem == 1)
         {
             Memory.WriteByte(Addresses.PermanentFireballAddress, (byte)1);
         } // else vanilla behavior, controlled by game.
@@ -552,12 +654,13 @@ public partial class App : Application
                 bool isRoboticaUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Robotica Farms Unlock")).Count() ?? 0) > 0;
                 bool isMetropolisUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Metropolis Unlock")).Count() ?? 0) > 0;
                 bool isDragonShoresUnlocked = (Client.GameState?.ReceivedItems.Where(x => x.Name == ("Dragon Shores Unlock")).Count() ?? 0) > 0;
+                // This order does not match the index order, for whatever reason.
                 bool[] winterUnlocks = [
                     isMysticUnlocked,
                     isCloudUnlocked,
-                    isCanyonUnlocked,
                     isRoboticaUnlocked,
                     isMetropolisUnlocked,
+                    isCanyonUnlocked,
                     isDragonShoresUnlocked
                 ];
                 uint portalAddress = Addresses.WinterPortalBlock;
@@ -578,7 +681,7 @@ public partial class App : Application
     }
     private static async void HandleMaxSparxHealth(object source, ElapsedEventArgs e)
     {
-        if (!Helpers.IsInGame())
+        if (!Helpers.IsInGame() || Client.GameState == null || Client.CurrentSession == null)
         {
             return;
         }
@@ -596,7 +699,12 @@ public partial class App : Application
     {
         // Avoid overwhelming the game when many cosmetic effects are received at once by processing only 1
         // every 5 seconds.  This also lets the user see effects when logging in asynchronously.
-        if (_cosmeticEffects.Count > 0 && Memory.ReadShort(Addresses.GameStatus) == (short)GameStatus.InGame)
+        if (
+            _cosmeticEffects.Count > 0 &&
+            Memory.ReadShort(Addresses.GameStatus) == (short)GameStatus.InGame &&
+            Client.GameState != null &&
+            Client.CurrentSession != null
+        )
         {
             string effect = _cosmeticEffects.Dequeue();
             switch (effect)
@@ -630,7 +738,7 @@ public partial class App : Application
     }
     private static void StartSpyroGame(object source, ElapsedEventArgs e)
     {
-        if (!Helpers.IsInGame())
+        if (!Helpers.IsInGame() || Client.GameState == null || Client.CurrentSession == null)
         {
             Log.Logger.Information("Player is not yet in game.");
             return;
@@ -643,8 +751,6 @@ public partial class App : Application
         Dictionary<string, uint> moneybagsAddresses = new Dictionary<string, uint>()
         {
             { "Crystal Glacier Bridge", Addresses.CrystalBridgeUnlock },
-            // v0.1.0 had a typo, so support both spellings.
-            { "Aquaria Tower Submarine", Addresses.AquariaSubUnlock },
             { "Aquaria Towers Submarine", Addresses.AquariaSubUnlock },
             { "Magma Cone Elevator", Addresses.MagmaElevatorUnlock },
             { "Swim", Addresses.SwimUnlock },
@@ -686,13 +792,87 @@ public partial class App : Application
                 }
             }
         }
+        // TODO: Handle this on game reset as well.
         int openWorldOption = int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString());
-        Log.Logger.Information($"{openWorldOption} {Client.Options?.GetValueOrDefault("enable_open_world", "0").ToString()}");
         if (openWorldOption != 0)
         {
             Memory.WriteByte(Addresses.CrushGuidebookUnlock, 1);
             Memory.WriteByte(Addresses.GulpGuidebookUnlock, 1);
-            // TODO: Determine whether or not to unlock Autumn and Winter.
+            if (int.Parse(Client.Options?.GetValueOrDefault("open_world_ability_and_warp_unlocks", "0").ToString()) != 0)
+            {
+                Memory.WriteByte(Addresses.AutumnGuidebookUnlock, 1);
+                Memory.WriteByte(Addresses.WinterGuidebookUnlock, 1);
+            }
+            Dictionary<string, uint[]> levelNames = new Dictionary<string, uint[]>()
+            {
+                { "Idol Springs", [Addresses.IdolNameAddress, Addresses.IdolNameAddress + 16] },
+                { "Colossus", [Addresses.ColossusNameAddress, Addresses.ColossusNameAddress + 12] },
+                { "Hurricos", [Addresses.HurricosNameAddress, Addresses.HurricosNameAddress + 12] },
+                { "Aquaria Towers", [Addresses.AquariaNameAddress, Addresses.AquariaNameAddress + 16] },
+                { "Sunny Beach", [Addresses.SunnyNameAddress, Addresses.SunnyNameAddress + 12] },
+                { "Ocean Speedway", [Addresses.OceanNameAddress, Addresses.OceanNameAddress + 16] },
+                { "Skelos Badlands", [Addresses.SkelosNameAddress, Addresses.SkelosNameAddress + 16] },
+                { "Crystal Glacier", [Addresses.CrystalNameAddress, Addresses.CrystalNameAddress + 16] },
+                { "Breeze Harbor", [Addresses.BreezeNameAddress, Addresses.BreezeNameAddress + 16] },
+                { "Zephyr", [Addresses.ZephyrNameAddress, Addresses.ZephyrNameAddress + 8] },
+                { "Metro Speedway", [Addresses.MetroNameAddress, Addresses.MetroNameAddress + 16] },
+                { "Scorch", [Addresses.ScorchNameAddress, Addresses.ScorchNameAddress + 8] },
+                { "Shady Oasis", [Addresses.ShadyNameAddress, Addresses.ShadyNameAddress + 12] },
+                { "Magma Cone", [Addresses.MagmaNameAddress, Addresses.MagmaNameAddress + 12] },
+                { "Fracture Hills", [Addresses.FractureNameAddress, Addresses.FractureNameAddress + 16] },
+                { "Icy Speedway", [Addresses.IcyNameAddress, Addresses.IcyNameAddress + 16] },
+                { "Mystic Marsh", [Addresses.MysticNameAddress, Addresses.MysticNameAddress + 16] },
+                { "Cloud Temples", [Addresses.CloudNameAddress, Addresses.CloudNameAddress + 16] },
+                { "Canyon Speedway", [Addresses.CanyonNameAddress, Addresses.CanyonNameAddress + 16] },
+                { "Robotica Farms", [Addresses.RoboticaNameAddress, Addresses.RoboticaNameAddress + 16] },
+                { "Metropolis", [Addresses.MetropolisNameAddress, Addresses.MetropolisNameAddress + 12] },
+                { "Dragon Shores", [Addresses.ShoresNameAddress, Addresses.ShoresNameAddress + 16] }
+            };
+            foreach (string levelName in levelNames.Keys)
+            {
+                uint[] nameAddresses = levelNames[levelName];
+                if ((Client.GameState?.ReceivedItems.Where(x => x.Name == $"{levelName} Unlock").Count() ?? 0) == 0)
+                {
+                    WriteStringToMemory(nameAddresses[0], nameAddresses[1], "LOCKED", padWithSpaces: false);
+                }
+                else
+                {
+                    WriteStringToMemory(nameAddresses[0], nameAddresses[1], levelName, padWithSpaces: false);
+                }
+            }
+        }
+        switch (_portalTextColor)
+        {
+            case PortalTextColor.Red:
+                Memory.WriteByte(Addresses.PortalTextRed, 128);
+                Memory.WriteByte(Addresses.PortalTextGreen, 0);
+                Memory.WriteByte(Addresses.PortalTextBlue, 0);
+                break;
+            case PortalTextColor.Green:
+                Memory.WriteByte(Addresses.PortalTextRed, 0);
+                Memory.WriteByte(Addresses.PortalTextGreen, 128);
+                Memory.WriteByte(Addresses.PortalTextBlue, 0);
+                break;
+            case PortalTextColor.Blue:
+                Memory.WriteByte(Addresses.PortalTextRed, 0);
+                Memory.WriteByte(Addresses.PortalTextGreen, 0);
+                Memory.WriteByte(Addresses.PortalTextBlue, 128);
+                break;
+            case PortalTextColor.Pink:
+                Memory.WriteByte(Addresses.PortalTextRed, 64);
+                Memory.WriteByte(Addresses.PortalTextGreen, 0);
+                Memory.WriteByte(Addresses.PortalTextBlue, 64);
+                break;
+            case PortalTextColor.White:
+                Memory.WriteByte(Addresses.PortalTextRed, 128);
+                Memory.WriteByte(Addresses.PortalTextGreen, 128);
+                Memory.WriteByte(Addresses.PortalTextBlue, 128);
+                break;
+            default:
+                Memory.WriteByte(Addresses.PortalTextRed, 64);
+                Memory.WriteByte(Addresses.PortalTextGreen, 64);
+                Memory.WriteByte(Addresses.PortalTextBlue, 0);
+                break;
         }
         _loadGameTimer.Enabled = false;
     }
@@ -708,7 +888,8 @@ public partial class App : Application
         var currentTokens = CalculateCurrentTokens();
         var currentGems = Memory.ReadShort(Addresses.TotalGemAddress);
         int goal = int.Parse(Client.Options?.GetValueOrDefault("goal", 0).ToString());
-        if ((CompletionGoal)goal == CompletionGoal.Ripto)
+        int isOpenWorld = int.Parse(Client.Options?.GetValueOrDefault("enable_open_world", 0).ToString());
+        if ((CompletionGoal)goal == CompletionGoal.Ripto || (CompletionGoal)goal == CompletionGoal.FourteenTali && isOpenWorld != 0)
         {
             if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == (int)ImportantLocationIDs.RiptoDefeated))
             {
@@ -742,7 +923,7 @@ public partial class App : Application
         }
         else if ((CompletionGoal)goal == CompletionGoal.HundredPercent)
         {
-            if (currentOrbs >= 64 && currentTalismans >= 14 && currentGems == 10000 && Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == (int)ImportantLocationIDs.RiptoDefeated))
+            if (currentOrbs >= 64 && (isOpenWorld != 0 || currentTalismans >= 14) && currentGems == 10000 && Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == (int)ImportantLocationIDs.RiptoDefeated))
             {
                 Client.SendGoalCompletion();
                 _hasSubmittedGoal = true;
@@ -869,7 +1050,11 @@ public partial class App : Application
     }
     private static void Locations_CheckedLocationsUpdated(System.Collections.ObjectModel.ReadOnlyCollection<long> newCheckedLocations)
     {
-        if (Client.GameState == null) return;
+        if (Client.GameState == null || Client.CurrentSession == null) return;
+        if (!Helpers.IsInGame())
+        {
+            Log.Logger.Error("Check sent while not in game. Please report this in the Discord thread!");
+        }
         CalculateCurrentTalismans();
         CalculateCurrentOrbs();
         CheckGoalCondition();
@@ -877,13 +1062,17 @@ public partial class App : Application
     /**
      * Writes a block of text to memory. endAddress will generally be the null terminator and will not be written to.
      */
-    private static void WriteStringToMemory(uint startAddress, uint endAddress, string stringToWrite)
+    private static void WriteStringToMemory(uint startAddress, uint endAddress, string stringToWrite, bool padWithSpaces=true)
     {
         uint address = startAddress;
         int stringIndex = 0;
         while (address < endAddress)
         {
             char charToWrite = ' ';
+            if (!padWithSpaces)
+            {
+                charToWrite = '\0';
+            }
             if (stringIndex < stringToWrite.Length)
             {
                 charToWrite = stringToWrite[stringIndex];
@@ -1010,6 +1199,7 @@ public partial class App : Application
         }
 
         _moneybagsOption = (MoneybagsOptions)int.Parse(Client.Options?.GetValueOrDefault("moneybags_settings", "0").ToString());
+        _portalTextColor = (PortalTextColor)int.Parse(Client.Options?.GetValueOrDefault("portal_gem_collection_color", "0").ToString());
 
         // Repopulate hint list.  There is likely a better way to do this using the Get network protocol
         // with keys=[$"hints_{team}_{slot}"].

--- a/source/S2AP/Helpers.cs
+++ b/source/S2AP/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿using Archipelago.Core.Models;
 using Archipelago.Core.Util;
+using Archipelago.MultiClient.Net.Models;
 using Avalonia.Logging;
 using S2AP.Models;
 using Serilog;
@@ -186,6 +187,41 @@ namespace S2AP
                         gemIndex++;
                     }
                 }
+                if (level.SpiritParticles > 0)
+                {
+                    List<ILocation> conditionsList = new List<ILocation>();
+                    Location spiritLocation = new Location()
+                    {
+                        Name = $"{level.Name}: All Spirit Particles count check",
+                        Id = -1,
+                        Address = Addresses.SpiritParticlesAddress,
+                        CheckType = LocationCheckType.Byte,
+                        CompareType = LocationCheckCompareType.GreaterThan,
+                        CheckValue = $"{level.SpiritParticles - 1}"
+                    };
+                    Location levelLocation = new Location()
+                    {
+                        Name = $"{level.Name}: All Spirit Particles level check",
+                        Id = -1,
+                        CheckType = LocationCheckType.Byte,
+                        Address = Addresses.CurrentLevelAddress,
+                        CompareType = LocationCheckCompareType.Match,
+                        CheckValue = $"{level.LevelId}",
+                    };
+                    conditionsList.Add(spiritLocation);
+                    conditionsList.Add(levelLocation);
+
+                    CompositeLocation spiritParticlesLocation = new CompositeLocation()
+                    {
+                        Name = $"{level.Name}: All Spirit Particles",
+                        Id = baseId + levelOffset * level.LevelId + locationOffset,
+                        CheckType = LocationCheckType.AND,
+                        Conditions = conditionsList,
+                        Category = "Spirit Particles"
+                    };
+                    locations.Add(spiritParticlesLocation);
+                    locationOffset++;
+                }
                 if (level.Name == "Dragon Shores")
                 {
                     for (int i = 0; i < 10; i++)
@@ -288,36 +324,36 @@ namespace S2AP
         {
             List<LevelData> levels = new List<LevelData>()
             {
-                new LevelData("Summer Forest", (int)LevelInGameIDs.SummerForest, 4, false, false, [Addresses.SwimUnlock, Addresses.WallToAquariaUnlock], [], [Addresses.SummerLifeBottle1Address, Addresses.SummerLifeBottle2Address, Addresses.SummerLifeBottle3Address], Addresses.SummerGemMask, 138, [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 96, 97, 98, 99, 100, 108, 126, 127, 128]),
+                new LevelData("Summer Forest", (int)LevelInGameIDs.SummerForest, 4, false, false, [Addresses.SwimUnlock, Addresses.WallToAquariaUnlock], [], [Addresses.SummerLifeBottle1Address, Addresses.SummerLifeBottle2Address, Addresses.SummerLifeBottle3Address], 0, Addresses.SummerGemMask, 138, [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 96, 97, 98, 99, 100, 108, 126, 127, 128]),
                 // Removed Moneybags as a location in Glimmer because it leads to an overly restrictive start.
-                new LevelData("Glimmer", (int)LevelInGameIDs.Glimmer, 3, true, false, [], [], [], Addresses.GlimmerGemMask, 133, [1, 2, 3, 4, 5, 6, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 152]),
-                new LevelData("Idol Springs", (int)LevelInGameIDs.IdolSprings, 2, true, false, [], [Addresses.IdolTikiSkillPoint], [Addresses.IdolLifeBottleAddress], Addresses.IdolGemMask, 149, [63, 88, 90, 122, 127, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145]),
-                new LevelData("Colossus", (int)LevelInGameIDs.Colossus, 3, true, false, [], [Addresses.ColossusHockeySkillPoint], [Addresses.ColossusLifeBottleAddress], Addresses.ColossusGemMask, 137, [1, 2, 3, 4, 5, 6, 7, 25, 32, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 71, 117, 118, 119, 127, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178]),
-                new LevelData("Hurricos", (int)LevelInGameIDs.Hurricos, 3, true, false, [], [Addresses.HurricosWindmillSkillPoint], [Addresses.HurricosLifeBottleAddress], Addresses.HurricosGemMask, 114, [42, 43, 44, 45, 46, 83, 85, 86, 87, 94, 116, 123, 126, 127, 128, 129, 130, 131]),
-                new LevelData("Aquaria Towers", (int)LevelInGameIDs.AquariaTowers, 3, true, false, [Addresses.AquariaSubUnlock], [Addresses.AquariaSeaweedSkillPoint], [Addresses.AquariaLifeBottleAddress], Addresses.AquariaGemMask, 137, [85, 86, 87, 88, 89, 90, 91, 92, 94, 95, 96, 97, 98, 99, 100, 109, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 167]),
-                new LevelData("Sunny Beach", (int)LevelInGameIDs.SunnyBeach, 3, true, false, [], [], [], Addresses.SunnyGemMask, 118, [1, 2, 3, 4, 5, 6, 53, 91, 105, 106, 107, 109]),
-                new LevelData("Ocean Speedway", (int)LevelInGameIDs.OceanSpeedway, 1, false, false, [], [Addresses.OceanTimeAttackSkillPoint], []),
-                new LevelData("Crush's Dungeon", (int)LevelInGameIDs.CrushsDungeon, 0, false, true, [], [Addresses.CrushPerfectSkillPoint], []),
-                new LevelData("Autumn Plains", (int)LevelInGameIDs.AutumnPlains, 2, false, false, [Addresses.ZephyrPortalUnlock, Addresses.ClimbUnlock, Addresses.ShadyPortalUnlock, Addresses.IcyPortalUnlock], [], [Addresses.AutumnLifeBottleAddress], Addresses.AutumnGemMask, 106, [1, 2, 3, 4, 5, 6, 102, 103, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133]),
-                new LevelData("Skelos Badlands", (int)LevelInGameIDs.SkelosBadlands, 3, true, false, [], [Addresses.SkelosCactiSkillPoint, Addresses.SkelosCatbatSkillPoint], [Addresses.SkelosLifeBottleAddress], Addresses.SkelosGemMask, 95, [1, 2, 3, 48, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 138, 139, 140, 141, 142, 143, 144, 155, 156, 157, 158, 159, 160, 161]),
-                new LevelData("Crystal Glacier", (int)LevelInGameIDs.CrystalGlacier, 2, true, false, [Addresses.CrystalBridgeUnlock], [], [Addresses.CrystalLifeBottleAddress], Addresses.CrystalGemMask, 105, [1, 2, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71]),
-                new LevelData("Breeze Harbor", (int)LevelInGameIDs.BreezeHarbor, 2, true, false, [], [], [Addresses.BreezeLifeBottle1Address, Addresses.BreezeLifeBottle2Address], Addresses.BreezeGemMask, 97, [1, 2, 3, 4, 5, 6, 7, 15, 16, 17, 18, 19, 85, 90, 100, 111, 112]),
-                new LevelData("Zephyr", (int)LevelInGameIDs.Zephyr, 4, true, false, [], [], [Addresses.ZephyrLifeBottleAddress], Addresses.ZephyrGemMask, 135, [1, 2, 8, 9, 10, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 105, 107, 117, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 149, 150, 151, 153, 167, 168]),
-                new LevelData("Metro Speedway", (int)LevelInGameIDs.MetroSpeedway, 1, false, false, [], [Addresses.MetroTimeAttackSkillPoint], []),
-                new LevelData("Scorch", (int)LevelInGameIDs.Scorch, 2, true, false, [], [Addresses.ScorchTreesSkillPoint], [Addresses.ScorchLifeBottleAddress], Addresses.ScorchGemMask, 125, [1, 2, 3, 4, 5, 93, 94, 95, 96, 97, 98, 99, 100, 101, 106, 115, 134, 135, 136, 137, 142, 143, 144, 148]),
-                new LevelData("Shady Oasis", (int)LevelInGameIDs.ShadyOasis, 2, true, false, [], [], [Addresses.ShadyLifeBottleAddress], Addresses.ShadyGemMask, 119, [1, 2, 3, 4, 5, 6, 7, 28, 29, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 138, 140, 141, 142, 143, 148, 155, 168, 169]),
-                new LevelData("Magma Cone", (int)LevelInGameIDs.MagmaCone, 3, true, false, [Addresses.MagmaElevatorUnlock], [], [Addresses.MagmaLifeBottle1Address, Addresses.MagmaLifeBottle2Address, Addresses.MagmaLifeBottle3Address, Addresses.MagmaLifeBottle4Address], Addresses.MagmaGemMask, 119, [1, 2, 48, 78, 121, 122, 123]),
-                new LevelData("Fracture Hills", (int)LevelInGameIDs.FractureHills, 3, true, false, [], [Addresses.FractureSuperchargeSkillPoint], [Addresses.FractureLifeBottleAddress], Addresses.FractureGemMask, 115, [1, 2, 3, 20, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 141]),
-                new LevelData("Icy Speedway", (int)LevelInGameIDs.IcySpeedway, 1, false, false, [], [Addresses.IcyTimeAttackSkillPoint], []),
-                new LevelData("Gulp's Overlook", (int)LevelInGameIDs.GulpsOverlook, 0, false, true, [], [Addresses.GulpPerfectSkillPoint, Addresses.GulpRiptoSkillPoint], []),
-                new LevelData("Winter Tundra", (int)LevelInGameIDs.WinterTundra, 3, false, false, [Addresses.CanyonPortalUnlock, Addresses.HeadbashUnlock], [], [], Addresses.WinterGemMask, 101, [1, 2, 3, 4, 5, 6, 7, 13, 14, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]),
-                new LevelData("Mystic Marsh", (int)LevelInGameIDs.MysticMarsh, 3, false, false, [], [], [Addresses.MysticLifeBottle1Address, Addresses.MysticLifeBottle2Address], Addresses.MysticGemMask, 139, [1, 112, 113, 114, 115, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157]),
-                new LevelData("Cloud Temples", (int)LevelInGameIDs.CloudTemples, 3, false, false, [], [], [Addresses.CloudLifeBottleAddress], Addresses.CloudGemMask, 111, [1, 34, 54, 55, 101, 102, 103]),
-                new LevelData("Canyon Speedway", (int)LevelInGameIDs.CanyonSpeedway, 1, false, false, [], [Addresses.CanyonTimeAttackSkillPoint], []),
-                new LevelData("Robotica Farms", (int)LevelInGameIDs.RoboticaFarms, 3, false, false, [], [], [], Addresses.RoboticaGemMask, 127, [1, 2, 3, 4, 5, 6, 7, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 130, 138, 139, 147, 148, 149, 150, 151, 152, 179, 180, 181, 182, 183]),
-                new LevelData("Metropolis", (int)LevelInGameIDs.Metropolis, 4, false, false, [], [], [], Addresses.MetropolisGemMask, 126, [38, 45, 65, 91, 97, 105, 129, 130, 131, 132]),
-                new LevelData("Dragon Shores", (int)LevelInGameIDs.DragonShores, 0, false, false, [], [], []),
-                new LevelData("Ripto's Arena", (int)LevelInGameIDs.RiptosArena, 0, false, true, [], [Addresses.RiptoPerfectSkillPoint], []),
+                new LevelData("Glimmer", (int)LevelInGameIDs.Glimmer, 3, true, false, [], [], [], 14, Addresses.GlimmerGemMask, 133, [1, 2, 3, 4, 5, 6, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 152]),
+                new LevelData("Idol Springs", (int)LevelInGameIDs.IdolSprings, 2, true, false, [], [Addresses.IdolTikiSkillPoint], [Addresses.IdolLifeBottleAddress], 11, Addresses.IdolGemMask, 149, [63, 88, 90, 122, 127, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145]),
+                new LevelData("Colossus", (int)LevelInGameIDs.Colossus, 3, true, false, [], [Addresses.ColossusHockeySkillPoint], [Addresses.ColossusLifeBottleAddress], 13, Addresses.ColossusGemMask, 137, [1, 2, 3, 4, 5, 6, 7, 25, 32, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 71, 117, 118, 119, 127, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178]),
+                new LevelData("Hurricos", (int)LevelInGameIDs.Hurricos, 3, true, false, [], [Addresses.HurricosWindmillSkillPoint], [Addresses.HurricosLifeBottleAddress], 22, Addresses.HurricosGemMask, 114, [42, 43, 44, 45, 46, 83, 85, 86, 87, 94, 116, 123, 126, 127, 128, 129, 130, 131]),
+                new LevelData("Aquaria Towers", (int)LevelInGameIDs.AquariaTowers, 3, true, false, [Addresses.AquariaSubUnlock], [Addresses.AquariaSeaweedSkillPoint], [Addresses.AquariaLifeBottleAddress], 29, Addresses.AquariaGemMask, 137, [85, 86, 87, 88, 89, 90, 91, 92, 94, 95, 96, 97, 98, 99, 100, 109, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 167]),
+                new LevelData("Sunny Beach", (int)LevelInGameIDs.SunnyBeach, 3, true, false, [], [], [], 17, Addresses.SunnyGemMask, 118, [1, 2, 3, 4, 5, 6, 53, 91, 105, 106, 107, 109]),
+                new LevelData("Ocean Speedway", (int)LevelInGameIDs.OceanSpeedway, 1, false, false, [], [Addresses.OceanTimeAttackSkillPoint], [], 0),
+                new LevelData("Crush's Dungeon", (int)LevelInGameIDs.CrushsDungeon, 0, false, true, [], [Addresses.CrushPerfectSkillPoint], [], 0),
+                new LevelData("Autumn Plains", (int)LevelInGameIDs.AutumnPlains, 2, false, false, [Addresses.ZephyrPortalUnlock, Addresses.ClimbUnlock, Addresses.ShadyPortalUnlock, Addresses.IcyPortalUnlock], [], [Addresses.AutumnLifeBottleAddress], 0, Addresses.AutumnGemMask, 106, [1, 2, 3, 4, 5, 6, 102, 103, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133]),
+                new LevelData("Skelos Badlands", (int)LevelInGameIDs.SkelosBadlands, 3, true, false, [], [Addresses.SkelosCactiSkillPoint, Addresses.SkelosCatbatSkillPoint], [Addresses.SkelosLifeBottleAddress], 28, Addresses.SkelosGemMask, 95, [1, 2, 3, 48, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 138, 139, 140, 141, 142, 143, 144, 155, 156, 157, 158, 159, 160, 161]),
+                new LevelData("Crystal Glacier", (int)LevelInGameIDs.CrystalGlacier, 2, true, false, [Addresses.CrystalBridgeUnlock], [], [Addresses.CrystalLifeBottleAddress], 38, Addresses.CrystalGemMask, 105, [1, 2, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71]),
+                new LevelData("Breeze Harbor", (int)LevelInGameIDs.BreezeHarbor, 2, true, false, [], [], [Addresses.BreezeLifeBottle1Address, Addresses.BreezeLifeBottle2Address], 16, Addresses.BreezeGemMask, 97, [1, 2, 3, 4, 5, 6, 7, 15, 16, 17, 18, 19, 85, 90, 100, 111, 112]),
+                new LevelData("Zephyr", (int)LevelInGameIDs.Zephyr, 4, true, false, [], [], [Addresses.ZephyrLifeBottleAddress], 30, Addresses.ZephyrGemMask, 135, [1, 2, 8, 9, 10, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 105, 107, 117, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 149, 150, 151, 153, 167, 168]),
+                new LevelData("Metro Speedway", (int)LevelInGameIDs.MetroSpeedway, 1, false, false, [], [Addresses.MetroTimeAttackSkillPoint], [], 0),
+                new LevelData("Scorch", (int)LevelInGameIDs.Scorch, 2, true, false, [], [Addresses.ScorchTreesSkillPoint], [Addresses.ScorchLifeBottleAddress], 28, Addresses.ScorchGemMask, 125, [1, 2, 3, 4, 5, 93, 94, 95, 96, 97, 98, 99, 100, 101, 106, 115, 134, 135, 136, 137, 142, 143, 144, 148]),
+                new LevelData("Shady Oasis", (int)LevelInGameIDs.ShadyOasis, 2, true, false, [], [], [Addresses.ShadyLifeBottleAddress], 21, Addresses.ShadyGemMask, 119, [1, 2, 3, 4, 5, 6, 7, 28, 29, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 138, 140, 141, 142, 143, 148, 155, 168, 169]),
+                new LevelData("Magma Cone", (int)LevelInGameIDs.MagmaCone, 3, true, false, [Addresses.MagmaElevatorUnlock], [], [Addresses.MagmaLifeBottle1Address, Addresses.MagmaLifeBottle2Address, Addresses.MagmaLifeBottle3Address, Addresses.MagmaLifeBottle4Address], 19, Addresses.MagmaGemMask, 119, [1, 2, 48, 78, 121, 122, 123]),
+                new LevelData("Fracture Hills", (int)LevelInGameIDs.FractureHills, 3, true, false, [], [Addresses.FractureSuperchargeSkillPoint], [Addresses.FractureLifeBottleAddress], 29, Addresses.FractureGemMask, 115, [1, 2, 3, 20, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 141]),
+                new LevelData("Icy Speedway", (int)LevelInGameIDs.IcySpeedway, 1, false, false, [], [Addresses.IcyTimeAttackSkillPoint], [], 0),
+                new LevelData("Gulp's Overlook", (int)LevelInGameIDs.GulpsOverlook, 0, false, true, [], [Addresses.GulpPerfectSkillPoint, Addresses.GulpRiptoSkillPoint], [], 0),
+                new LevelData("Winter Tundra", (int)LevelInGameIDs.WinterTundra, 3, false, false, [Addresses.CanyonPortalUnlock, Addresses.HeadbashUnlock], [], [], 0, Addresses.WinterGemMask, 101, [1, 2, 3, 4, 5, 6, 7, 13, 14, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]),
+                new LevelData("Mystic Marsh", (int)LevelInGameIDs.MysticMarsh, 3, false, false, [], [], [Addresses.MysticLifeBottle1Address, Addresses.MysticLifeBottle2Address], 36, Addresses.MysticGemMask, 139, [1, 112, 113, 114, 115, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157]),
+                new LevelData("Cloud Temples", (int)LevelInGameIDs.CloudTemples, 3, false, false, [], [], [Addresses.CloudLifeBottleAddress], 23, Addresses.CloudGemMask, 111, [1, 34, 54, 55, 101, 102, 103]),
+                new LevelData("Canyon Speedway", (int)LevelInGameIDs.CanyonSpeedway, 1, false, false, [], [Addresses.CanyonTimeAttackSkillPoint], [], 0),
+                new LevelData("Robotica Farms", (int)LevelInGameIDs.RoboticaFarms, 3, false, false, [], [], [], 20, Addresses.RoboticaGemMask, 127, [1, 2, 3, 4, 5, 6, 7, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 130, 138, 139, 147, 148, 149, 150, 151, 152, 179, 180, 181, 182, 183]),
+                new LevelData("Metropolis", (int)LevelInGameIDs.Metropolis, 4, false, false, [], [], [], 22, Addresses.MetropolisGemMask, 126, [38, 45, 65, 91, 97, 105, 129, 130, 131, 132]),
+                new LevelData("Dragon Shores", (int)LevelInGameIDs.DragonShores, 0, false, false, [], [], [], 0),
+                new LevelData("Ripto's Arena", (int)LevelInGameIDs.RiptosArena, 0, false, true, [], [Addresses.RiptoPerfectSkillPoint], [], 0),
             };
             return levels;
         }

--- a/source/S2AP/Helpers.cs
+++ b/source/S2AP/Helpers.cs
@@ -47,8 +47,12 @@ namespace S2AP
             }
             return result;
         }
-        public static List<ILocation> BuildLocationList(bool includeGemsanity=false)
+        public static List<ILocation> BuildLocationList(bool includeGemsanity=false, List<int> gemsanityIDs = null)
         {
+            if (gemsanityIDs == null)
+            {
+                gemsanityIDs = new List<int>();
+            }
             int baseId = 1230000;
             int levelOffset = 1000;
             int processedSkillPoints = 0;
@@ -174,7 +178,7 @@ namespace S2AP
                             CheckType = LocationCheckType.Bit,
                             Category = "Gemsanity"
                         };
-                        if (includeGemsanity)
+                        if (includeGemsanity && gemsanityIDs.Contains(baseId + levelOffset * level.LevelId + locationOffset))
                         {
                             locations.Add(gemsLocation);
                         }
@@ -202,7 +206,6 @@ namespace S2AP
                 }
                 currentTalismanAddress++;
                 currentOrbAddress++;
-                currentGemAddress += 4;
             }
             baseId = 1259000;
             for (int i = 0; i < 20; i++)
@@ -276,6 +279,7 @@ namespace S2AP
                     locations.Add(gem100Location);
                     offset++;
                 }
+                currentGemAddress += 4;
             }
             return locations;
         }
@@ -284,7 +288,7 @@ namespace S2AP
         {
             List<LevelData> levels = new List<LevelData>()
             {
-                new LevelData("Summer Forest", (int)LevelInGameIDs.SummerForest, 4, false, false, [Addresses.SwimUnlock, Addresses.WallToAquariaUnlock], [], [Addresses.SummerLifeBottle1Address, Addresses.SummerLifeBottle2Address, Addresses.SummerLifeBottle3Address], Addresses.SummerGemMask, 138, [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 97, 98, 99, 100, 108, 126, 127, 128]),
+                new LevelData("Summer Forest", (int)LevelInGameIDs.SummerForest, 4, false, false, [Addresses.SwimUnlock, Addresses.WallToAquariaUnlock], [], [Addresses.SummerLifeBottle1Address, Addresses.SummerLifeBottle2Address, Addresses.SummerLifeBottle3Address], Addresses.SummerGemMask, 138, [27, 39, 41, 42, 43, 44, 45, 46, 47, 61, 62, 72, 73, 81, 82, 95, 96, 97, 98, 99, 100, 108, 126, 127, 128]),
                 // Removed Moneybags as a location in Glimmer because it leads to an overly restrictive start.
                 new LevelData("Glimmer", (int)LevelInGameIDs.Glimmer, 3, true, false, [], [], [], Addresses.GlimmerGemMask, 133, [1, 2, 3, 4, 5, 6, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 152]),
                 new LevelData("Idol Springs", (int)LevelInGameIDs.IdolSprings, 2, true, false, [], [Addresses.IdolTikiSkillPoint], [Addresses.IdolLifeBottleAddress], Addresses.IdolGemMask, 149, [63, 88, 90, 122, 127, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145]),

--- a/source/S2AP/Models/Enums.cs
+++ b/source/S2AP/Models/Enums.cs
@@ -65,7 +65,18 @@
         {
             Vanilla = 0,
             InPool = 1,
-            AlwaysOff = 2
+            AlwaysOff = 2,
+            StartWith = 3
+        }
+
+        public enum PortalTextColor
+        {
+            Default = 0,
+            Red = 1,
+            Green = 2,
+            Blue = 3,
+            Pink = 4,
+            White = 5
         }
 
         public enum ImportantLocationIDs : int

--- a/source/S2AP/Models/LevelData.cs
+++ b/source/S2AP/Models/LevelData.cs
@@ -12,6 +12,7 @@ namespace S2AP.Models
         public uint[] MoneybagsAddresses { get; set; }
         public uint[] SkillPointAddresses { get; set; }
         public List<uint>[] LifeBottleAddresses { get; set; }
+        public int SpiritParticles { get; set; }
         public uint GemMaskAddress { get; set; }
         public int TotalGemCount { get; set; }
         public int[] GemSkipIndices { get; set; }
@@ -24,6 +25,7 @@ namespace S2AP.Models
             uint[] moneybagsAddresses,
             uint[] skillPointAddresses,
             List<uint>[] lifeBottleAddresses,
+            int spiritParticles,
             uint gemMaskAddress = 0x0,
             int totalGemCount = 0,
             int[] gemSkipIndices = null
@@ -37,6 +39,7 @@ namespace S2AP.Models
             MoneybagsAddresses = moneybagsAddresses;
             SkillPointAddresses = skillPointAddresses;
             LifeBottleAddresses = lifeBottleAddresses;
+            SpiritParticles = spiritParticles;
             GemMaskAddress = gemMaskAddress;
             TotalGemCount = totalGemCount;
             if (gemSkipIndices == null)


### PR DESCRIPTION
Changes:
- Warns if not running in admin mode, tries to always run in admin mode
- Add option to start with fireball
- Progressive Client Stability Improvement
- Open World mode with level unlocks.
- First cosmetic randomizer effect.
- All spirit particles in a level is now a check
- Fixed bug where Glimmer marked the wrong gems as climb-locked.

Known issues:
- Roughly 0.03% of valid seeds failed to generate.  These tend to be when total gem checks are on with a high number.