### PR TITLE
Gemsanity Bundle Size YAML Setting (for version 1.2)

### DIFF
--- a/apworld/spyro2/Items.py
+++ b/apworld/spyro2/Items.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from typing import NamedTuple
 from BaseClasses import Item
-from .Options import MoneybagsOptions, SparxUpgradeOptions, AbilityOptions, GemsanityOptions, GoalOptions, LevelLockOptions
+from .Options import GemsanityRewardOptions, MoneybagsOptions, SparxUpgradeOptions, AbilityOptions, GemsanityOptions, GoalOptions, LevelLockOptions
 from Options import OptionError
 
 
@@ -216,27 +216,27 @@ _all_items = [Spyro2ItemData(row[0], row[1], row[2]) for row in [
     ("Metropolis Gold Gem", 4103, Spyro2ItemCategory.GEM),
     ("Metropolis Pink Gem", 4104, Spyro2ItemCategory.GEM),
 
-    ("Summer Forest 50 Gems", 4200, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Glimmer 50 Gems", 4201, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Idol Springs 50 Gems", 4202, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Colossus 50 Gems", 4203, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Hurricos 50 Gems", 4204, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Aquaria Towers 50 Gems", 4205, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Sunny Beach 50 Gems", 4206, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Autumn Plains 50 Gems", 4207, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Skelos Badlands 50 Gems", 4208, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Crystal Glacier 50 Gems", 4209, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Breeze Harbor 50 Gems", 4210, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Zephyr 50 Gems", 4211, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Scorch 50 Gems", 4212, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Shady Oasis 50 Gems", 4213, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Magma Cone 50 Gems", 4214, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Fracture Hills 50 Gems", 4215, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Winter Tundra 50 Gems", 4216, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Mystic Marsh 50 Gems", 4217, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Cloud Temples 50 Gems", 4218, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Robotica Farms 50 Gems", 4219, Spyro2ItemCategory.GEMSANITY_PARTIAL),
-    ("Metropolis 50 Gems", 4220, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Summer Forest Gem Bundle", 4200, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Glimmer Gem Bundle", 4201, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Idol Springs Gem Bundle", 4202, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Colossus Gem Bundle", 4203, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Hurricos Gem Bundle", 4204, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Aquaria Towers Gem Bundle", 4205, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Sunny Beach Gem Bundle", 4206, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Autumn Plains Gem Bundle", 4207, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Skelos Badlands Gem Bundle", 4208, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Crystal Glacier Gem Bundle", 4209, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Breeze Harbor Gem Bundle", 4210, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Zephyr Gem Bundle", 4211, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Scorch Gem Bundle", 4212, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Shady Oasis Gem Bundle", 4213, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Magma Cone Gem Bundle", 4214, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Fracture Hills Gem Bundle", 4215, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Winter Tundra Gem Bundle", 4216, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Mystic Marsh Gem Bundle", 4217, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Cloud Temples Gem Bundle", 4218, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Robotica Farms Gem Bundle", 4219, Spyro2ItemCategory.GEMSANITY_PARTIAL),
+    ("Metropolis Gem Bundle", 4220, Spyro2ItemCategory.GEMSANITY_PARTIAL),
 
     ("Glitched Item", 9000, Spyro2ItemCategory.UT_ITEM)
 ]]
@@ -318,31 +318,32 @@ def BuildItemPool(world, count, options, locked_levels):
         remaining_count = remaining_count - 1
 
     if options.enable_gemsanity.value == GemsanityOptions.PARTIAL or \
-            options.enable_gemsanity.value == GemsanityOptions.FULL and not options.full_gemsanity_individual_gems.value:
-        for i in range(8):
-            item_pool.append(item_dictionary["Summer Forest 50 Gems"])
-            item_pool.append(item_dictionary["Glimmer 50 Gems"])
-            item_pool.append(item_dictionary["Idol Springs 50 Gems"])
-            item_pool.append(item_dictionary["Colossus 50 Gems"])
-            item_pool.append(item_dictionary["Hurricos 50 Gems"])
-            item_pool.append(item_dictionary["Aquaria Towers 50 Gems"])
-            item_pool.append(item_dictionary["Sunny Beach 50 Gems"])
-            item_pool.append(item_dictionary["Autumn Plains 50 Gems"])
-            item_pool.append(item_dictionary["Skelos Badlands 50 Gems"])
-            item_pool.append(item_dictionary["Crystal Glacier 50 Gems"])
-            item_pool.append(item_dictionary["Breeze Harbor 50 Gems"])
-            item_pool.append(item_dictionary["Zephyr 50 Gems"])
-            item_pool.append(item_dictionary["Scorch 50 Gems"])
-            item_pool.append(item_dictionary["Shady Oasis 50 Gems"])
-            item_pool.append(item_dictionary["Magma Cone 50 Gems"])
-            item_pool.append(item_dictionary["Fracture Hills 50 Gems"])
-            item_pool.append(item_dictionary["Winter Tundra 50 Gems"])
-            item_pool.append(item_dictionary["Mystic Marsh 50 Gems"])
-            item_pool.append(item_dictionary["Cloud Temples 50 Gems"])
-            item_pool.append(item_dictionary["Robotica Farms 50 Gems"])
-            item_pool.append(item_dictionary["Metropolis 50 Gems"])
-        remaining_count -= 168
-    elif options.enable_gemsanity.value == GemsanityOptions.FULL and options.full_gemsanity_individual_gems.value:
+            options.enable_gemsanity.value == GemsanityOptions.FULL and options.gemsanity_reward_type.value == GemsanityRewardOptions.BUNDLES:
+        bundle_count = int(400 / options.gemsanity_gem_bundle_size)
+        for i in range(bundle_count):
+            item_pool.append(item_dictionary["Summer Forest Gem Bundle"])
+            item_pool.append(item_dictionary["Glimmer Gem Bundle"])
+            item_pool.append(item_dictionary["Idol Springs Gem Bundle"])
+            item_pool.append(item_dictionary["Colossus Gem Bundle"])
+            item_pool.append(item_dictionary["Hurricos Gem Bundle"])
+            item_pool.append(item_dictionary["Aquaria Towers Gem Bundle"])
+            item_pool.append(item_dictionary["Sunny Beach Gem Bundle"])
+            item_pool.append(item_dictionary["Autumn Plains Gem Bundle"])
+            item_pool.append(item_dictionary["Skelos Badlands Gem Bundle"])
+            item_pool.append(item_dictionary["Crystal Glacier Gem Bundle"])
+            item_pool.append(item_dictionary["Breeze Harbor Gem Bundle"])
+            item_pool.append(item_dictionary["Zephyr Gem Bundle"])
+            item_pool.append(item_dictionary["Scorch Gem Bundle"])
+            item_pool.append(item_dictionary["Shady Oasis Gem Bundle"])
+            item_pool.append(item_dictionary["Magma Cone Gem Bundle"])
+            item_pool.append(item_dictionary["Fracture Hills Gem Bundle"])
+            item_pool.append(item_dictionary["Winter Tundra Gem Bundle"])
+            item_pool.append(item_dictionary["Mystic Marsh Gem Bundle"])
+            item_pool.append(item_dictionary["Cloud Temples Gem Bundle"])
+            item_pool.append(item_dictionary["Robotica Farms Gem Bundle"])
+            item_pool.append(item_dictionary["Metropolis Gem Bundle"])
+        remaining_count -= bundle_count * 21
+    elif options.enable_gemsanity.value == GemsanityOptions.FULL and options.gemsanity_reward_type.value == GemsanityRewardOptions.GEMS:
         for i in range(60):
             item_pool.append(item_dictionary["Summer Forest Red Gem"])
         for i in range(40):

--- a/apworld/spyro2/Locations.py
+++ b/apworld/spyro2/Locations.py
@@ -681,9 +681,15 @@ location_dictionary: Dict[str, Spyro2LocationData] = {}
 for location_table in location_tables.values():
     location_dictionary.update({location_data.name: location_data for location_data in location_table})
 
-location_name_groups = {"Speedways": set(), "Speedway Orbs": set()}
+location_name_groups = {"Speedways": set(), "Speedway Orbs": set(), "Gemsanity (All)": set()}
+levelnames = ["Summer Forest" , "Glimmer" , "Idol Springs" , "Colossus" , "Hurricos" , "Aquaria Towers" , "Sunny Beach" , "Autumn Plains" , "Skelos Badlands" , "Crystal Glacier" , "Breeze Harbor" , "Zephyr" , "Scorch" , "Shady Oasis" , "Magma Cone" , "Fracture Hills" , "Winter Tundra" , "Mystic Marsh" , "Cloud Temples" , "Robotica Farms" , "Metropolis"]
 speedways = ["Ocean Speedway", "Metro Speedway", "Icy Speedway", "Canyon Speedway"]
+for level in levelnames:
+    location_name_groups.update({"Gemsanity (" + level + ")": set()})
 for location in location_dictionary.keys():
+    if location_dictionary[location].category == Spyro2LocationCategory.GEM:
+        location_name_groups["Gemsanity (All)"].add(location)
+        location_name_groups["Gemsanity (" + location.split(":")[0] + ")"].add(location)
     for speedway in speedways:
         if location.startswith(speedway):
             location_name_groups["Speedways"].add(location)

--- a/apworld/spyro2/Logic.py
+++ b/apworld/spyro2/Logic.py
@@ -45,7 +45,7 @@ class Logic(ABC):
         count += state.count(f"{level} Blue Gem", self.world.player) * 5
         count += state.count(f"{level} Gold Gem", self.world.player) * 10
         count += state.count(f"{level} Pink Gem", self.world.player) * 25
-        count += state.count(f"{level} 50 Gems", self.world.player) * 50
+        count += state.count(f"{level} Gem Bundle", self.world.player) * self.world.options.gemsanity_gem_bundle_size
         return count
 
     def has_sparx_health(self, health, state):

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -32,6 +32,10 @@ class GemsanityLocationOptions:
     LOCAL = 0
     GLOBAL = 1
 
+class GemsanityRewardOptions:
+    BUNDLES = 0
+    GEMS = 1
+
 class SparxUpgradeOptions:
     OFF = 0
     BLUE = 1
@@ -237,9 +241,9 @@ class EnableGemsanityOption(Choice):
     Full requires the host to edit allow_full_gemsanity
         in their yaml file, as it is very disruptive.
     Off: Individual gems are not checks.
-    Partial: 200 randomly chosen gems become checks. For every level
-        with loose gems (not speedways), 8 items giving 50 gems for
-        that level will be added to the pool.
+    Partial: Only some number of randomly chosen gems become checks. For every
+        level with loose gems (not speedways), Gem Bundle items giving
+        gems for that level will be added to the pool.
     Full: All gems are checks."""
     display_name = "Enable Gemsanity"
     default = GemsanityOptions.OFF
@@ -256,11 +260,43 @@ class GemsanityItemLocations(Choice):
     option_local = GemsanityLocationOptions.LOCAL
     option_global = GemsanityLocationOptions.GLOBAL
 
-class FullGemsanityUseIndividualGems(Toggle):
-    """Should gem items be bundles of 50 gems each,
-     or individual gems. Applies only to full gemsanity.
-     Turning this on slows down generation significantly."""
-    display_name = "Full Gemsanity Use Individual Gem Items"
+class GemsanityRewardType(Choice):
+     """Adds item rewards to the pool to match the applicable gem locations.
+     Gems: If Gemsanity is set to FULL, each gem location in the game will have
+         its individual matching gem added to the item pool. Applies only to
+         full gemsanity. Choosing this slows down generation significantly.
+     Bundles: Adds items that grant a number of gems for an individual level
+         to the item pool.
+         If Gemsanity=FULL, extra gem locations may contain other/filler items.
+         If Gemsanity=PARTIAL, This option is selected automatically"""
+     display_name = "Gemsanity Item Reward Type"
+     default = GemsanityRewardOptions.BUNDLES
+     option_gems = GemsanityRewardOptions.GEMS
+     option_bundles = GemsanityRewardOptions.BUNDLES
+ 
+class GemsanityGemBundleSize(Choice):
+     """Define the amount of gems awarded by each Gem Bundle item.
+     Determines how many items are added to the item pool.
+     Determines how many gem locations are randomly selected if
+         Gemsanity is set to Partial (sdds one location per bundle item).
+     WARNING: Selecting an option smaller than 25 requires the host to
+         edit allow_full_gemsanity in their yaml file.
+     Default (50):adds 8 Gem Bundles per Level to the Item Pool (168 Total)
+     10: 40 Bundles/Level (840 Total) ,  16: 25 Bundles/level (525 Total)
+     20: 20 Bundles/Level (420 Total) ,  25: 16 Bundles/Level (336 Total)
+     40: 10 Bundles/Level (210 Total) ,  50: 8 Bundles/Level (168 Total)
+     80: 5 Bundles/Level (105 Total)  ,  100: 4 Bundles/Level (84 Total)"""
+     display_name = "Gem Bundle Item Size"
+     default = 50
+     #option_5 = 5 #Dropped support due to Fuzzer Impact in solo worlds. will re-assess in future releases
+     option_10 = 10
+     option_16 = 16
+     option_20 = 20
+     option_25 = 25
+     option_40 = 40
+     option_50 = 50
+     option_80 = 80
+     option_100 = 100
 
 class MoneybagsSettings(Choice):
     """Settings for Moneybags unlocks.
@@ -543,7 +579,8 @@ class Spyro2Option(PerGameCommonOptions):
     enable_spirit_particle_checks: EnableSpiritParticleChecksOption
     enable_gemsanity: EnableGemsanityOption
     gemsanity_item_locations: GemsanityItemLocations
-    full_gemsanity_individual_gems: FullGemsanityUseIndividualGems
+    gemsanity_reward_type: GemsanityRewardType
+    gemsanity_gem_bundle_size: GemsanityGemBundleSize
     moneybags_settings: MoneybagsSettings
     death_link: EnableDeathLink
     enable_filler_extra_lives: EnableFillerExtraLives
@@ -589,7 +626,8 @@ spyro_options_groups = [
             MaxTotalGemCheckOption,
             EnableGemsanityOption,
             GemsanityItemLocations,
-            FullGemsanityUseIndividualGems,
+            GemsanityRewardType,
+            GemsanityGemBundleSize,
             EnableSkillpointChecksOption,
             EnableLifeBottleChecksOption,
             EnableSpiritParticleChecksOption

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -14,7 +14,7 @@ from .Items import (Spyro2Item, Spyro2ItemCategory, item_dictionary, key_item_na
 from .Locations import (Spyro2Location, Spyro2LocationCategory, location_tables,
     location_dictionary, location_name_groups)
 from .Options import Spyro2Option, GoalOptions, GemsanityOptions, GemsanityLocationOptions, MoneybagsOptions, \
-    RandomizeGemColorOptions, LevelLockOptions, TrickDifficultyOptions, spyro_options_groups, AbilityOptions
+    RandomizeGemColorOptions, LevelLockOptions, TrickDifficultyOptions, spyro_options_groups, AbilityOptions, GemsanityRewardOptions
 from .Logic import Logic, BaseLogic, EasyLogic, MediumLogic, CustomLogic
 from .Rules import get_level_rules
 
@@ -136,7 +136,20 @@ class Spyro2World(World):
             self.enabled_location_categories.add(Spyro2LocationCategory.LIFE_BOTTLE)
         if self.options.enable_gemsanity.value != GemsanityOptions.OFF:
             self.enabled_location_categories.add(Spyro2LocationCategory.GEM)
-        if self.options.enable_gemsanity.value == GemsanityOptions.PARTIAL:
+        bundle_count = int(21 * 400 / self.options.gemsanity_gem_bundle_size)
+        if not self.settings.allow_full_gemsanity and self.multiworld.players > 1:
+            if self.options.enable_gemsanity.value == GemsanityOptions.FULL:
+                 raise OptionError(f"Spyro 2: Player {self.player_name} has gemsanity set to full, which adds 2546 locations "
+                                  f"and up to that many progression items to the pool and may result in long generation times. "
+                                  f"They must either switch to partial gemsanity, or the "
+                                  f"host needs to enable allow_full_gemsanity in their host.yaml settings.")
+            if bundle_count > 400 and self.options.gemsanity_reward_type.value == GemsanityRewardOptions.BUNDLES and self.options.enable_gemsanity.value != GemsanityOptions.OFF:
+                 raise OptionError(f"Spyro 2: Player {self.player_name} has their gemsanity gem bundle size set to [{self.options.gemsanity_gem_bundle_size.value}] "
+                                  f"which is attempting to add [{bundle_count}] progression items (and locations) to the pool and may "
+                                  f"result in long generation times. They must switch to a larger bundle size (less items to place). "
+                                  f"Alternatively, the host can enable allow_full_gemsanity in their host.yaml settings to authorize "
+                                  f"up to 2600 progression items (per spyro gemsanity player) to be added to the item pool.")
+        if  self.options.enable_gemsanity.value == GemsanityOptions.PARTIAL:
             all_gem_locations = []
             for location in location_dictionary:
                 if location_dictionary[location].category == Spyro2LocationCategory.GEM:
@@ -146,13 +159,8 @@ class Spyro2World(World):
             if is_ut:
                 self.chosen_gem_locations = []
             else:
-                self.chosen_gem_locations = self.multiworld.random.sample(all_gem_locations, k=200)
-        if self.options.enable_gemsanity.value == GemsanityOptions.FULL:
-            if not self.settings.allow_full_gemsanity and self.multiworld.players > 1:
-                raise OptionError(f"Spyro 2: Player {self.player_name} has gemsanity set to full, which adds 2546 locations "
-                                  f"and up to that many progression items to the pool and may result in long generation times. "
-                                  f"They must either switch to partial gemsanity, or the "
-                                  f"host needs to enable allow_full_gemsanity in their host.yaml settings.")
+                self.chosen_gem_locations = self.multiworld.random.sample(all_gem_locations, k=bundle_count)
+            
         if self.options.gemsanity_item_locations.value == GemsanityLocationOptions.LOCAL:
             for itemname, item in item_dictionary.items():
                 if item.category in [Spyro2ItemCategory.GEM, Spyro2ItemCategory.GEMSANITY_PARTIAL]:
@@ -693,6 +701,9 @@ class Spyro2World(World):
                 "enable_life_bottle_checks": self.options.enable_life_bottle_checks.value,
                 "enable_spirit_particle_checks": self.options.enable_spirit_particle_checks.value,
                 "enable_gemsanity": self.options.enable_gemsanity.value,
+                "gemsanity_item_locations": self.options.gemsanity_item_locations.value,
+                "gemsanity_reward_type": self.options.gemsanity_reward_type.value,
+                "gemsanity_gem_bundle_size": self.options.gemsanity_gem_bundle_size.value,
                 "moneybags_settings": self.options.moneybags_settings.value,
                 "death_link": self.options.death_link.value,
                 "enable_filler_extra_lives": self.options.enable_filler_extra_lives.value,

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -2001,6 +2001,7 @@ public partial class App : Application
         uint levelGemCountAddress = Addresses.LevelGemsAddress;
         int totalGems = 0;
         int i = 0;
+        int bundle_size = int.Parse(Client.Options?.GetValueOrDefault("gemsanity_gem_bundle_size", "0").ToString());
         foreach (LevelData level in Helpers.GetLevelData())
         {
             if (!level.Name.Contains("Speedway"))
@@ -2011,7 +2012,7 @@ public partial class App : Application
                 levelGemCount += 5 * (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x != null && x.ItemName == $"{levelName} Blue Gem").Count() ?? 0);
                 levelGemCount += 10 * (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x != null && x.ItemName == $"{levelName} Gold Gem").Count() ?? 0);
                 levelGemCount += 25 * (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x != null && x.ItemName == $"{levelName} Pink Gem").Count() ?? 0);
-                levelGemCount += 50 * (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x != null && x.ItemName == $"{levelName} 50 Gems").Count() ?? 0);
+                levelGemCount += bundle_size * (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x != null && x.ItemName == $"{levelName} Gem Bundle").Count() ?? 0);
                 Memory.Write(levelGemCountAddress, levelGemCount);
                 totalGems += levelGemCount;
             } else


### PR DESCRIPTION
Created a yaml setting to define the number of gems awarded by the "50 gems" item. Option may be any integer factor of 400 between 10 and 100
 - Renamed this reward item to "Gem Bundle"
 - if Gemsaninty is set to partial, the number of gem locations randomly selected will be determined by the bundle size option (values range from 84 [Size:100] to 840 [Size:10])
  - If Gemsanity is set to partial, lowered the number of random locations selected for Bundle Size 50 (the old static value) from 200 to 168 (due to change above)
 - Added generation exception if the player tries to add more than 400* gem bundle items into a multiworld without "Allow_Full_Gemsanity" in the host settings. (this does not trigger outside a multiworld) (*occurs if Gem Bundle size is smaller than 25)
 - Added these and other missing gemsanity yaml settings to the Player Slot Data
 - Defined each gemsanity location into the location group "Gemsanity (All)" and added 21 additional groups for each "Gemsanity (LEVEL)"