### PR TITLE
#143 - Fix Bizhawk Token Checks

### DIFF
--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -1146,9 +1146,8 @@ class Spyro2Client(BizHawkClient):
             if level.Name == "Dragon Shores":
                 for i in range(10):
                     id = base_id + level_offset * level.LevelId + i
-                    if ctx.slot_data["options"]["goal"] == GoalOptions.TEN_TOKENS:
-                        if shores_tokens[4 * i] != 0 and id not in self.locations_list:
-                            tokensToSend.add(id)
+                    if shores_tokens[4 * i] != 0 and id not in self.locations_list:
+                        tokensToSend.add(id)
                     location_offset += 1
             level_index += 1
 


### PR DESCRIPTION
This bug (#143) was caused by a change to the APWorld late in the 2.0.0 release cycle that made shores tokens checks regardless of settings.

Right now these are always locations, but if that changes, the Bizhawk client code removes locations that are not remaining checks before sending to the server, so no extra packets should be sent.

No changes to logic, so no fuzzer testing required.

Testing completed with a goal of Ripto in Bizhawk:
<img width="2304" height="1109" alt="image" src="https://github.com/user-attachments/assets/65a44777-9182-4a42-aa38-ae9cd8c03e99" />
