### PR TITLE
#134 - Fix Desyncing Sparx Health

### DIFF
--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -246,7 +246,7 @@ class Spyro2Client(BizHawkClient):
 
     apworld_manifest = orjson.loads(pkgutil.get_data(__name__, "archipelago.json").decode("utf-8"))
     client_version = apworld_manifest["world_version"]
-    supported_versions = ["2.0.0", "2.0.0-rc"]
+    supported_versions = ["2.0.0", "2.0.0-rc", "2.0.1"]
 
     boolsyncprogress = False
     syncWaitConfirm = False

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -60,7 +60,7 @@ class Spyro2World(World):
     enabled_location_categories: Set[Spyro2LocationCategory]
     required_client_version = (0, 5, 0)
     # TODO: Remember to update this!
-    ap_world_version = "2.0.0"
+    ap_world_version = "2.0.1"
     item_name_to_id = Spyro2Item.get_name_to_id()
     location_name_to_id = Spyro2Location.get_name_to_id()
     item_name_groups = item_name_groups

--- a/apworld/spyro2/archipelago.json
+++ b/apworld/spyro2/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Spyro 2",
-  "world_version": "2.0.0",
+  "world_version": "2.0.1",
   "minimum_ap_version": "0.6.1",
   "authors": ["Uroogla"],
   "poptracker": "github.com/routhken/Spyro_2_tracker/releases/latest",

--- a/source/S2AP.Desktop/S2AP.Desktop.csproj
+++ b/source/S2AP.Desktop/S2AP.Desktop.csproj
@@ -15,9 +15,9 @@
     <!-- App Identifier -->
     <ApplicationId>com.uroogla.s2ap</ApplicationId>
     <!-- Versions -->
-    <ApplicationDisplayVersion>1.2.0</ApplicationDisplayVersion>
-    <ApplicationVersion>1.2.0</ApplicationVersion>
-    <Version>1.2.0</Version>
+    <ApplicationDisplayVersion>2.0.1</ApplicationDisplayVersion>
+    <ApplicationVersion>2.0.1</ApplicationVersion>
+    <Version>2.0.1</Version>
 	  <ApplicationManifest>app.manifest</ApplicationManifest>
     <!-- Single File Publishing Properties -->
     <PublishSingleFile>true</PublishSingleFile>

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -39,8 +39,8 @@ namespace S2AP;
 public partial class App : Application
 {
     // TODO: Remember to set this in S2AP.Desktop as well.
-    public static string Version = "2.0.0";
-    public static List<string> SupportedVersions = ["1.2.0-rc", "1.2.0", "2.0.0-rc", "2.0.0"];
+    public static string Version = "2.0.1";
+    public static List<string> SupportedVersions = ["1.2.0-rc", "1.2.0", "2.0.0-rc", "2.0.0", "2.0.1"];
 
     public static MainWindowViewModel Context;
     public static ArchipelagoClient Client { get; set; }
@@ -48,7 +48,6 @@ public partial class App : Application
     public static List<ILocation> GameLocations { get; set; }
     private static readonly object _lockObject = new object();
     private static ConcurrentQueue<string> _cosmeticEffects { get; set; }
-    private static byte _sparxUpgrades { get; set; }
     private static bool _hasSubmittedGoal { get; set; }
     private static bool _useQuietHints { get; set; }
     private static int _unlockedLevels { get; set; }
@@ -166,7 +165,6 @@ public partial class App : Application
         }
         Context.Host = lastConnectionDetails["host"];
         Context.Slot = lastConnectionDetails["slot"];
-        _sparxUpgrades = 0;
         _hasSubmittedGoal = false;
         _useQuietHints = true;
         // No level ID set
@@ -752,7 +750,7 @@ public partial class App : Application
                     }
                     break;
                 case "Progressive Sparx Health Upgrade":
-                    _sparxUpgrades++;
+                    // To avoid desyncs, these are recounted in real time.
                     break;
                 case "Double Jump Ability":
                 case "Permanent Fireball Ability":
@@ -1347,14 +1345,23 @@ public partial class App : Application
             return;
         }
         byte currentHealth = Memory.ReadByte(Addresses.PlayerHealth);
-        // Don't adjust negative health, which breaks deathlink.
-        if (currentHealth <= 128 && currentHealth > _sparxUpgrades)
+        // Doing these checks trades efficency for correctness.
+        // We could probably do this check only upon connecting or receiving
+        // a health upgrade, but this is guaranteed to be correct.
+        ProgressiveSparxHealthOptions sparxOption = (ProgressiveSparxHealthOptions)int.Parse(Client.Options?.GetValueOrDefault("enable_progressive_sparx_health", "0").ToString());
+        byte maxHealth = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Progressive Sparx Health Upgrade").Count() ?? 0);
+        if (sparxOption == ProgressiveSparxHealthOptions.Blue)
         {
-            Memory.WriteByte(Addresses.PlayerHealth, _sparxUpgrades);
+            maxHealth += 2;
         }
-        if (_sparxUpgrades == 3)
+        else if (sparxOption == ProgressiveSparxHealthOptions.Green)
         {
-            _sparxTimer.Enabled = false;
+            maxHealth += 1;
+        }
+        // Don't adjust negative health, which breaks deathlink.
+        if (currentHealth <= 128 && currentHealth > maxHealth)
+        {
+            Memory.WriteByte(Addresses.PlayerHealth, maxHealth);
         }
     }
     
@@ -2076,15 +2083,6 @@ public partial class App : Application
         ProgressiveSparxHealthOptions sparxOption = (ProgressiveSparxHealthOptions)int.Parse(Client.Options?.GetValueOrDefault("enable_progressive_sparx_health", "0").ToString());
         if (sparxOption != ProgressiveSparxHealthOptions.Off)
         {
-            _sparxUpgrades = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Progressive Sparx Health Upgrade").Count() ?? 0);
-            if (sparxOption == ProgressiveSparxHealthOptions.Blue)
-            {
-                _sparxUpgrades += 2;
-            }
-            else if (sparxOption == ProgressiveSparxHealthOptions.Green)
-            {
-                _sparxUpgrades += 1;
-            }
             _sparxTimer = new Timer();
             _sparxTimer.Elapsed += new ElapsedEventHandler(HandleMaxSparxHealth);
             _sparxTimer.Interval = 500;
@@ -2118,7 +2116,6 @@ public partial class App : Application
     private static void OnDisconnected(object sender, EventArgs args)
     {
         // Avoid ongoing timers affecting a new game.
-        _sparxUpgrades = 0;
         _hasSubmittedGoal = false;
         _useQuietHints = true;
         _handleGemsanity = false;


### PR DESCRIPTION
Addresses #134 and bumps version number.

The bug occurred when the player received a progressive sparx health upgrade since last connecting, since the upgrade was already part of the list of received items but then was then double counted during processing the new items. Additionally, when the incorrect calculation reached a max health of 3, the health checker turned itself off, meaning the issue wouldn't fix itself until the player reconnected.

This solution ensures correctness at the cost of some extra calculations.

Bizhawk already functioned correctly, as it recalculated max health each game loop.

No APWorld changes.  Tested the client by sending upgrades early and once connected while testing spawn and fodder behavior.