### PR TITLE
#139 - Exclude Cutscenes from Code Writes

### DIFF
--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -913,7 +913,7 @@ class Spyro2Client(BizHawkClient):
                 ]
                 await self.locations_handling(ctx, Locations_Reads)
 
-            if not boolIsFirstBoot and gameStatus not in [GameStatus.Paused, GameStatus.LoadingWorld]:
+            if not boolIsFirstBoot and gameStatus not in [GameStatus.Paused, GameStatus.LoadingWorld, GameStatus.Cutscene]:
                 # ======== Gemsanity Code Handling ========
                 if ctx.slot_data["options"]["enable_gemsanity"]:
                     gemsanity_reads = [localGemIncrement, globalGemIncrement, globalGemRespawnFix, localGemRespawnFix, playBeep]

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -1077,7 +1077,7 @@ public partial class App : Application
                 }
             }
 
-            if (gameStatus != GameStatus.Paused && gameStatus != GameStatus.LoadingWorld)
+            if (gameStatus != GameStatus.Paused && gameStatus != GameStatus.LoadingWorld && gameStatus != GameStatus.Cutscene)
             {
                 if (gemsanityOption != GemsanityOptions.Off)
                 {


### PR DESCRIPTION
Resolves #139 

Prevents writing code to memory during cutscenes before and after levels. These cutscenes have different data in memory than the normal level, despite the level ID being the same.  This means that we could potentially crash a cutscene by writing at the wrong time.

No changes requiring fuzzing.

Client changes tested by using the memory watcher on lines we write (for example, Idol Springs 0x82010), checking how it changes in the vanilla game, with the old client, and with the patched version.  Confirmed that the old client wrote early but the new one does not.