### PR TITLE
#77 - Make shark deaths trigger deathlink

### DIFF
--- a/apworld/spyro2/Addresses.py
+++ b/apworld/spyro2/Addresses.py
@@ -265,6 +265,10 @@ class RAM:
     lastReceivedArchipelagoID = 0x1c0
     tempLastReceivedArchipelagoID = 0x1c4
 
+    AquariaSharkDeathJAL = 0x788e8
+    AquariaSharkDeathlink = 0x84788
+    AquariaSharkDeathlinkCode = 0x84790
+
 class ROM:
     RomDialogueOrbCount = 0x3ec0c
     OrbCountCode = [0x2c, 0x70, 0x22, 0xac]

--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -638,6 +638,8 @@ class Spyro2Client(BizHawkClient):
                 "animationLength": (RAM.PlayerAnimationLength, 4, "MainRAM"),
                 "spyroState": (RAM.SpyroStateAddress, 1, "MainRAM"),
                 "spyroVelocityFlag": (RAM.PlayerVelocityStatus, 1, "MainRAM"),
+                "aquariaSharkDeathlinkCode": (RAM.AquariaSharkDeathlinkCode, 4, "MainRAM"),
+                "sharkDeathlinkValue": (RAM.AquariaSharkDeathlink, 4, "MainRAM"),
             }
 
             readTuples = [Value for Value in readsDict.values()]
@@ -723,6 +725,8 @@ class Spyro2Client(BizHawkClient):
             animationLength = readValues["animationLength"]
             spyroState = readValues["spyroState"]
             spyroVelocityFlag = readValues["spyroVelocityFlag"]
+            aquariaSharkDeathlinkCode = readValues["aquariaSharkDeathlinkCode"]
+            sharkDeathlinkValue = readValues["sharkDeathlinkValue"]
 
             # Write tables
             itemsWrites = []
@@ -986,6 +990,15 @@ class Spyro2Client(BizHawkClient):
                     if len(eloraDoorWrites) > 0:
                         await bizhawk.write(ctx.bizhawk_ctx, eloraDoorWrites)
 
+                # ======== Aquaria Shark Deathlink Handling ========
+                sharkDeathlinkReads = [
+                    currentLevel,
+                    aquariaSharkDeathlinkCode
+                ]
+                sharkDeathlinkWrites = self.handleAquariaSharkDeathlink(sharkDeathlinkReads)
+                if len(sharkDeathlinkWrites) > 0:
+                    await bizhawk.write(ctx.bizhawk_ctx, sharkDeathlinkWrites)
+
                 # ======== Open World Handling ========
                 openWorldReads = [crushGuidebookUnlock, gulpGuidebookUnlock, autumnGuidebookUnlock, winterGuidebookUnlock]
                 openWorldWrites = self.handleOpenWorldChanges(ctx, openWorldReads)
@@ -1030,7 +1043,8 @@ class Spyro2Client(BizHawkClient):
                     zPos,
                     animationLength,
                     spyroVelocityFlag,
-                    spyroState
+                    spyroState,
+                    sharkDeathlinkValue
                 ]
                 await self.handle_death_link(ctx, DL_Reads)
 
@@ -1609,6 +1623,30 @@ class Spyro2Client(BizHawkClient):
         # }
         return eloraDoorWrites
 
+    def handleAquariaSharkDeathlink(self, aquariaSharkWrites):
+        currentLevel = aquariaSharkWrites[0]
+        deathlinkWriteLine = aquariaSharkWrites[1]
+
+        sharkDeathlinkWrites = []
+
+        if currentLevel == LevelInGameIDs.AquariaTowers and deathlinkWriteLine != 0x24020001:
+            # Take an empty block of space and use it for DeathLink handling code for sharks.
+            # This block sets Addresses.AquariaSharkDeathlink to 1 if the sharks kill Spyro, then calls normal OnDeath code.
+            sharkDeathlinkWrites += [
+                (RAM.AquariaSharkDeathlinkCode, 0x24020001.to_bytes(4, "little"), "MainRAM"),      # li v0, 0x1
+                (RAM.AquariaSharkDeathlinkCode + 4, 0x3c018008.to_bytes(4, "little"), "MainRAM"),  # lui at, 0x8008
+                (RAM.AquariaSharkDeathlinkCode + 8, 0xac224788.to_bytes(4, "little"), "MainRAM"),  # sw v0, 0x4788(at)
+                (RAM.AquariaSharkDeathlinkCode + 12, 0x0.to_bytes(4, "little"), "MainRAM"),        # nop
+                (RAM.AquariaSharkDeathlinkCode + 16, 0x0c00cb9d.to_bytes(4, "little"), "MainRAM"), # jal OnDeath (0x80032e74)
+                (RAM.AquariaSharkDeathlinkCode + 20, 0x0.to_bytes(4, "little"), "MainRAM"),        # nop
+                (RAM.AquariaSharkDeathlinkCode + 24, 0x0801e23c.to_bytes(4, "little"), "MainRAM"), # j 0x800788f0 (AquariaSharkDeathJAL + 8)
+                (RAM.AquariaSharkDeathJAL + 28, 0x0.to_bytes(4, "little"), "MainRAM"),             # nop
+
+                (RAM.AquariaSharkDeathJAL, 0x080211e4.to_bytes(4, "little"), "MainRAM"),           # j 0x80084790 (AquariaSharkDeathlinkCode)
+            ]
+        return sharkDeathlinkWrites
+
+
     def handleOpenWorldChanges(self, ctx, openWorldReads):
         crushGuidebookUnlock = openWorldReads[0]
         gulpGuidebookUnlock = openWorldReads[1]
@@ -1876,6 +1914,7 @@ class Spyro2Client(BizHawkClient):
         animationLength = DL_Reads[4]
         velocityFlag = DL_Reads[5]
         spyroState = DL_Reads[6]
+        sharkDeathlinkValue = DL_Reads[7]
 
         DL_writes = []
         if self.deathlink == 1:
@@ -1884,7 +1923,7 @@ class Spyro2Client(BizHawkClient):
             if "DeathLink" in ctx.tags and ctx.last_death_link + 1 < time.time():
                 if not self.sending_death_link and \
                         currentLevel in deathLinkLevels and \
-                        gameState not in [GameStatus.Cutscene, GameStatus.Loading, GameStatus.TitleScreen]:
+                        gameState not in [GameStatus.Cutscene, GameStatus.Loading, GameStatus.LoadingWorld, GameStatus.TitleScreen]:
                     cause = None
                     if health > 128:
                         cause = "Damage"
@@ -1898,6 +1937,8 @@ class Spyro2Client(BizHawkClient):
                         cause = "Drowned"
                     elif spyroState == SpyroStates.DeathSquash:
                         cause = "Squashed"
+                    elif currentLevel == LevelInGameIDs.AquariaTowers and gameState != GameStatus.Paused and sharkDeathlinkValue != 0:
+                        cause = "Eaten by sharks"
                     if cause is not None:
                         await self.send_deathlink(ctx, cause)
                 # Player has respawned.
@@ -1906,7 +1947,8 @@ class Spyro2Client(BizHawkClient):
                             not (spyroState == SpyroStates.Flop and velocityFlag == 1 and 0x3b < animationLength) and \
                             spyroState != SpyroStates.DeathBurn and \
                             not (spyroState == SpyroStates.DeathDrowning and animationLength >= 116) and \
-                            spyroState != SpyroStates.DeathSquash:
+                            spyroState != SpyroStates.DeathSquash and \
+                            not (currentLevel == LevelInGameIDs.AquariaTowers and gameState != GameStatus.Paused and sharkDeathlinkValue != 0):
                         self.sending_death_link = False
             if self.pending_death_link:
                 if currentLevel not in deathLinkLevels:
@@ -1922,6 +1964,8 @@ class Spyro2Client(BizHawkClient):
 
     async def send_deathlink(self, ctx: "BizHawkClientContext", cause) -> None:
         self.sending_death_link = True
+        DL_writes = [(RAM.AquariaSharkDeathlink, 0x0.to_bytes(4, "little"), "MainRAM")]
+        await bizhawk.write(ctx.bizhawk_ctx, DL_writes)
         ctx.last_death_link = time.time()
         if cause == "Unknown":
             DeathText = ctx.player_names[ctx.slot] + " died in Spyro 2."

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -250,6 +250,10 @@ namespace S2AP
         public static uint ShadyHeadbashCheck = 0x7d6c0;
         public static uint GulpDoubleDamage = 0x120c5e;
 
+        public static uint AquariaSharkDeathJAL = 0x788e8;
+        public static uint AquariaSharkDeathlink = 0x84788;
+        public static uint AquariaSharkDeathlinkCode = 0x84790;
+
         public const uint GuidebookText = 0x00010308;
 
         public const uint AnalogReadAddressOne = 0x12320;

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -978,31 +978,32 @@ public partial class App : Application
                 int animationLength = Memory.ReadInt(Addresses.PlayerAnimationLength);
                 byte spyroState = Memory.ReadByte(Addresses.SpyroStateAddress);
                 byte spyroVelocityFlag = Memory.ReadByte(Addresses.PlayerVelocityStatus);
+                int sharkDeathLink = Memory.ReadInt(Addresses.AquariaSharkDeathlink);
                 LevelInGameIDs[] deathLinkLevels = [
                     LevelInGameIDs.SummerForest,
-                LevelInGameIDs.Glimmer,
-                LevelInGameIDs.Colossus,
-                LevelInGameIDs.IdolSprings,
-                LevelInGameIDs.Hurricos,
-                LevelInGameIDs.SunnyBeach,
-                LevelInGameIDs.AquariaTowers,
-                LevelInGameIDs.CrushsDungeon,
-                LevelInGameIDs.AutumnPlains,
-                LevelInGameIDs.BreezeHarbor,
-                LevelInGameIDs.SkelosBadlands,
-                LevelInGameIDs.CrystalGlacier,
-                LevelInGameIDs.Zephyr,
-                LevelInGameIDs.Scorch,
-                LevelInGameIDs.FractureHills,
-                LevelInGameIDs.MagmaCone,
-                LevelInGameIDs.ShadyOasis,
-                LevelInGameIDs.GulpsOverlook,
-                LevelInGameIDs.WinterTundra,
-                LevelInGameIDs.MysticMarsh,
-                LevelInGameIDs.CloudTemples,
-                LevelInGameIDs.RoboticaFarms,
-                LevelInGameIDs.Metropolis,
-                LevelInGameIDs.RiptosArena
+                    LevelInGameIDs.Glimmer,
+                    LevelInGameIDs.Colossus,
+                    LevelInGameIDs.IdolSprings,
+                    LevelInGameIDs.Hurricos,
+                    LevelInGameIDs.SunnyBeach,
+                    LevelInGameIDs.AquariaTowers,
+                    LevelInGameIDs.CrushsDungeon,
+                    LevelInGameIDs.AutumnPlains,
+                    LevelInGameIDs.BreezeHarbor,
+                    LevelInGameIDs.SkelosBadlands,
+                    LevelInGameIDs.CrystalGlacier,
+                    LevelInGameIDs.Zephyr,
+                    LevelInGameIDs.Scorch,
+                    LevelInGameIDs.FractureHills,
+                    LevelInGameIDs.MagmaCone,
+                    LevelInGameIDs.ShadyOasis,
+                    LevelInGameIDs.GulpsOverlook,
+                    LevelInGameIDs.WinterTundra,
+                    LevelInGameIDs.MysticMarsh,
+                    LevelInGameIDs.CloudTemples,
+                    LevelInGameIDs.RoboticaFarms,
+                    LevelInGameIDs.Metropolis,
+                    LevelInGameIDs.RiptosArena
                 ];
 
                 if (
@@ -1013,6 +1014,7 @@ public partial class App : Application
                     deathLinkLevels.Contains(currentLevel) &&
                     gameStatus != GameStatus.Cutscene &&
                     gameStatus != GameStatus.Loading &&
+                    gameStatus != GameStatus.LoadingWorld &&
                     gameStatus != GameStatus.TitleScreen &&
                     (
                         health > 128 ||
@@ -1020,7 +1022,8 @@ public partial class App : Application
                         (spyroState == (byte)SpyroStates.Flop && spyroVelocityFlag == 1 && 0x3b < animationLength) ||
                         spyroState == (byte)SpyroStates.DeathBurn ||
                         spyroState == (byte)SpyroStates.DeathDrowning && animationLength >= 116 ||
-                        spyroState == (byte)SpyroStates.DeathSquash
+                        spyroState == (byte)SpyroStates.DeathSquash ||
+                        currentLevel == LevelInGameIDs.AquariaTowers && gameStatus != GameStatus.Paused && sharkDeathLink != 0
                     )
                 )
                 {
@@ -1050,6 +1053,11 @@ public partial class App : Application
                     {
                         deathlinkCause = "Squashed";
                     }
+                    else if (currentLevel == LevelInGameIDs.AquariaTowers && gameStatus != GameStatus.Paused && sharkDeathLink != 0)
+                    {
+                        deathlinkCause = "Eaten by sharks";
+                        Memory.Write(Addresses.AquariaSharkDeathlink, 0);
+                    }
                     Log.Logger.Information($"Sending DeathLink. Cause: {deathlinkCause}");
                     if (deathlinkCause == "Unknown")
                     {
@@ -1068,7 +1076,8 @@ public partial class App : Application
                         (spyroState == (byte)SpyroStates.Flop && spyroVelocityFlag == 1 && 0x3b < animationLength) ||
                         spyroState == (byte)SpyroStates.DeathBurn ||
                         spyroState == (byte)SpyroStates.DeathDrowning && animationLength >= 116 ||
-                        spyroState == (byte)SpyroStates.DeathSquash
+                        spyroState == (byte)SpyroStates.DeathSquash ||
+                        currentLevel == LevelInGameIDs.AquariaTowers && gameStatus != GameStatus.Paused && sharkDeathLink != 0
                     )
                 )
                 {
@@ -1126,6 +1135,21 @@ public partial class App : Application
                             Memory.Write(thiefZCoordinate, 0);
                         }
                     }
+                }
+                else if (currentLevel == LevelInGameIDs.AquariaTowers)
+                {
+                    // Take an empty block of space and use it for DeathLink handling code for sharks.
+                    // This block sets Addresses.AquariaSharkDeathlink to 1 if the sharks kill Spyro, then calls normal OnDeath code.
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode, 0x24020001);      // li v0, 0x1
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 4, 0x3c018008);  // lui at, 0x8008
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 8, 0xac224788);  // sw v0, 0x4788(at)
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 12, 0x0);        // nop
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 16, 0x0c00cb9d); // jal OnDeath (0x80032e74)
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 20, 0x0);        // nop
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 24, 0x0801e23c); // j 0x800788f0 (AquariaSharkDeathJAL + 8)
+                    Memory.Write(Addresses.AquariaSharkDeathlinkCode + 28, 0x0);        // nop
+
+                    Memory.Write(Addresses.AquariaSharkDeathJAL, 0x080211e4);           // j 0x80084790 (AquariaSharkDeathlinkCode)
                 }
                 else if (currentLevel == LevelInGameIDs.BreezeHarbor)
                 {


### PR DESCRIPTION
Partially resolves #77 

Adds custom code during Aquaria Towers tracking deaths to sharks for deathlink.

No logic changes.

Clients tested using multiple deathlink causes, repeated, to ensure the values send and clear properly.