### PR TITLE
#156 - Remove OptionErrors around trap percentage

### DIFF
--- a/apworld/spyro2/Items.py
+++ b/apworld/spyro2/Items.py
@@ -613,14 +613,13 @@ def BuildItemPool(world, count, options, locked_levels):
             for i in range(0, 4):
                 allowed_misc_items.append(item)
 
+    trap_percent = options.trap_filler_percent.value
     if remaining_count > 0 and options.trap_filler_percent.value > 0 and len(allowed_trap_items) == 0:
-        raise OptionError(f"Trap percentage is set to {options.trap_filler_percent.value}, but none have been turned on.")
-    if remaining_count > 0 and options.trap_filler_percent.value < 100 and len(allowed_misc_items) == 0:
-        raise OptionError(f"{100 - options.trap_filler_percent.value} percent of filler items are meant to be non-traps, but no non-trap items have been turned on.")
+        trap_percent = 0
 
     # Get the correct blend of traps and filler items.
     for i in range(remaining_count):
-        if multiworld.random.random() * 100 < options.trap_filler_percent.value:
+        if multiworld.random.random() * 100 < trap_percent:
             itemList = [item for item in allowed_trap_items]
         else:
             itemList = [item for item in allowed_misc_items]


### PR DESCRIPTION
Resolves #156 

This PR brings S2AP in line with S3AP and completes a user request. This makes random settings work better and will improve UT support as well - at present UT can fail to generate if the user randomizes the trap% option.

Testing Results:

Unit Tests all pass

Before and after comparison of fuzzing is not directly comparable, since this significantly reduces the number of cases that are ignored.

General Test
2.0.0
Success: 8678
Failures: 9 (0.1%)
Timeouts: 14 (0.16%)
Ignored: 1299

Time taken:923.71s

#156 
Success: 9910
Failures: 14 (0.14%)
Timeouts: 17 (0.17%)
Ignored: 59

Time taken:1091.49s

With Empty Hook
#156 
Success: 10530
Failures: 2 (0.02%)
Timeouts: 0
Ignored: 4468

Time taken:193.73s

Universal Tracker Hook
#156
Success: 991
Failures: 2 (0.2%)
Timeouts: 0
Ignored: 7

All failures are known/existing fill error issues.  Rates are in line with expectation.