### PR TITLE
#145 - Fix Extra 400/400 Popups in Gemsanity

### DIFF
--- a/apworld/spyro2/Addresses.py
+++ b/apworld/spyro2/Addresses.py
@@ -155,6 +155,7 @@ class RAM:
     localGemLoadFixAddress = 0x00076B98
     globalGemLoadFixAddress = 0x00076BA0
     playBeepAddress = 0x5429c
+    gemPopupAddress = 0x39734
 
     # Address of portal surface flags.
     SummerPortalBlock = 0x000e2d34

--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -589,6 +589,7 @@ class Spyro2Client(BizHawkClient):
                 "globalGemRespawnFix": (RAM.globalGemRespawnFixAddress, 4, "MainRAM"),
                 "localGemRespawnFix": (RAM.localGemRespawnFixAddress, 4, "MainRAM"),
                 "playBeep": (RAM.playBeepAddress, 4, "MainRAM"),
+                "gemPopup": (RAM.gemPopupAddress, 4, "MainRAM"),
                 "doubleJumpLine1": (RAM.DoubleJumpAddress1, 4, "MainRAM"),
                 "doubleJumpLine2": (RAM.DoubleJumpAddress2, 4, "MainRAM"),
                 "permanentFireball": (RAM.PermanentFireballAddress, 1, "MainRAM"),
@@ -674,6 +675,7 @@ class Spyro2Client(BizHawkClient):
             globalGemRespawnFix = readValues["globalGemRespawnFix"]
             localGemRespawnFix = readValues["localGemRespawnFix"]
             playBeep = readValues["playBeep"]
+            gemPopup = readValues["gemPopup"]
             doubleJumpLine1 = readValues["doubleJumpLine1"]
             doubleJumpLine2 = readValues["doubleJumpLine2"]
             permanentFireball = readValues["permanentFireball"]
@@ -916,7 +918,7 @@ class Spyro2Client(BizHawkClient):
             if not boolIsFirstBoot and gameStatus not in [GameStatus.Paused, GameStatus.LoadingWorld, GameStatus.Cutscene]:
                 # ======== Gemsanity Code Handling ========
                 if ctx.slot_data["options"]["enable_gemsanity"]:
-                    gemsanity_reads = [localGemIncrement, globalGemIncrement, globalGemRespawnFix, localGemRespawnFix, playBeep]
+                    gemsanity_reads = [localGemIncrement, globalGemIncrement, globalGemRespawnFix, localGemRespawnFix, playBeep, gemPopup]
                     gemsanityWrites = self.handleGemsanity(gemsanity_reads)
                     if len(gemsanityWrites) > 0:
                         await bizhawk.write(ctx.bizhawk_ctx, gemsanityWrites)
@@ -1283,6 +1285,7 @@ class Spyro2Client(BizHawkClient):
         globalGemRespawnFix = gemsanity_reads[2]
         localGemRespawnFix = gemsanity_reads[3]
         playBeep = gemsanity_reads[4]
+        gemPopup = gemsanity_reads[5]
         gemsanity_writes = []
 
         # Disable updating local and global gem counts on collecting a gem, loading into a level, and respawning.
@@ -1296,6 +1299,8 @@ class Spyro2Client(BizHawkClient):
             gemsanity_writes += [(RAM.localGemRespawnFixAddress, (0).to_bytes(4, "little"), "MainRAM")]
         if playBeep != 0:
             gemsanity_writes += [(RAM.playBeepAddress, (0).to_bytes(4, "little"), "MainRAM")]
+        if gemPopup == 0x14620012:   # bne v1,v0,0x80039780
+            gemsanity_writes += [(RAM.gemPopupAddress, (0x0800e5e0).to_bytes(4, "little"), "MainRAM")]  # j 0x80039780
 
         return gemsanity_writes
 

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -152,6 +152,7 @@ namespace S2AP
         public const uint localGemLoadFixAddress = 0x00076B98;
         public const uint globalGemLoadFixAddress = 0x00076BA0;
         public const uint playBeepAddress = 0x5429c;
+        public const uint gemPopupAddress = 0x39734;
 
         public const uint SummerPortalBlock = 0x000e2d34;
         public const uint AutumnPortalBlock = 0x000f5330;

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -1089,6 +1089,13 @@ public partial class App : Application
                     // Probably easier to just patch.
                     //Memory.Write(Addresses.localGemLoadFixAddress, 0);
                     //Memory.Write(Addresses.globalGemLoadFixAddress, 0);
+
+                    // Disable repeated 400/400 popup by always skipping the code instead of when gem count is not 400.
+                    uint gemPopupCode = Memory.ReadUInt(Addresses.gemPopupAddress);
+                    if (gemPopupCode == 0x14620012)                             // bne v1,v0,0x80039780
+                    {
+                        Memory.Write(Addresses.gemPopupAddress, 0x0800e5e0);    // j 0x80039780
+                    }
                 }
                 if (currentLevel == LevelInGameIDs.Colossus)
                 {


### PR DESCRIPTION
Resolves #145 

This prevents the 400/400 popup from being spammed in gemsanity when the player has received all bundles/gems but has not collected all gems in the level.  Confirmed the level complete popup is not spammed.

No logic changes

Tested on both Duckstation and Bizhawk by checking gem collection before and after receiving all 400 gems, for both non-locations and locations.  Compared the behavior before and after the change.