### PR TITLE
#144 - Add Musicsanity

### DIFF
--- a/apworld/spyro2/Addresses.py
+++ b/apworld/spyro2/Addresses.py
@@ -262,6 +262,11 @@ class RAM:
     WTDoorGemBit = 7
     WTWarpAddress = 0x6470a
 
+    MainLevelMusicArray = 0x60140
+    FullMusicArray = 0x64de4
+    CurrentMusicData = 0x68320
+    CurrentMusicStatus = 0x682f4
+
     lastReceivedArchipelagoID = 0x1c0
     tempLastReceivedArchipelagoID = 0x1c4
 

--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -638,6 +638,9 @@ class Spyro2Client(BizHawkClient):
                 "animationLength": (RAM.PlayerAnimationLength, 4, "MainRAM"),
                 "spyroState": (RAM.SpyroStateAddress, 1, "MainRAM"),
                 "spyroVelocityFlag": (RAM.PlayerVelocityStatus, 1, "MainRAM"),
+                "mainLevelSongs": (RAM.MainLevelMusicArray, 29, "MainRAM"),
+                "fullMusicArray": (RAM.FullMusicArray, 8 * 39, "MainRAM"),
+                "currentMusicData": (RAM.CurrentMusicData, 16, "MainRAM"),
             }
 
             readTuples = [Value for Value in readsDict.values()]
@@ -723,6 +726,9 @@ class Spyro2Client(BizHawkClient):
             animationLength = readValues["animationLength"]
             spyroState = readValues["spyroState"]
             spyroVelocityFlag = readValues["spyroVelocityFlag"]
+            mainLevelSongs = readValues["mainLevelSongs"]
+            fullMusicArray = readValues["fullMusicArray"]
+            currentMusicData = readValues["currentMusicData"]
 
             # Write tables
             itemsWrites = []
@@ -979,7 +985,10 @@ class Spyro2Client(BizHawkClient):
 
                 # ======== Musicsanity Handling ========
                 musicChangeReads = [
-
+                    currentLevel,
+                    mainLevelSongs,
+                    fullMusicArray,
+                    currentMusicData
                 ]
                 musicChangeWrites = self.handleMusicChanges(ctx, musicChangeReads)
                 if len(musicChangeWrites) > 0:
@@ -1588,46 +1597,35 @@ class Spyro2Client(BizHawkClient):
         return colorChangeWrites
 
     def handleMusicChanges(self, ctx, musicChangeReads):
-        songs = musicChangeReads[0]
-
-        music_changes = ctx.slot_data["options"]["main_level_music_array_changes"]
-        for levelID in music_changes.keys():
-            pass
+        current_level = musicChangeReads[0]
+        main_level_songs = musicChangeReads[1].to_bytes(29, "little")
+        full_music_array = musicChangeReads[2].to_bytes(8 * 39, "little")
+        current_music_data = musicChangeReads[3].to_bytes(16, "little")
 
         musicChangeWrites = []
 
-        #  bool musicValuesChanged = false;
-    #         if (mainLevelMusicChanges != null)
-    #         {
-    #             foreach (int levelID in mainLevelMusicChanges.Keys)
-    #             {
-    #                 byte song = Memory.ReadByte(Addresses.MainLevelMusicArray + (uint)levelID);
-    #                 if (song != (byte)mainLevelMusicChanges[levelID])
-    #                 {
-    #                     Memory.WriteByte(Addresses.MainLevelMusicArray + (uint)levelID, (byte)mainLevelMusicChanges[levelID]);
-    #                     musicValuesChanged = true;
-    #                 }
-    #             }
-    #         }
-    #         if (musicValuesChanged)
-    #         {
-    #             byte currentLevel = Memory.ReadByte(Addresses.CurrentLevelAddress);
-    #             if (mainLevelMusicChanges.ContainsKey((int)currentLevel))
-    #             {
-    #                 uint currentLevelSongStartOffset = 0x15f90 + Memory.ReadUInt(Addresses.FullMusicArray + (uint)(8 * mainLevelMusicChanges[(int)currentLevel]));
-    #                 uint currentLevelSongTimestamp = Memory.ReadUInt(Addresses.CurrentMusicData + 4);
-    #                 ushort currentLevelSongLength = Memory.ReadUShort(Addresses.FullMusicArray + (uint)(4 + 8 * mainLevelMusicChanges[(int)currentLevel]));
-    #                 short currentLevelSongChannel = Memory.ReadShort(Addresses.FullMusicArray + (uint)(6 + 8 * mainLevelMusicChanges[(int)currentLevel]));
-    #                 Memory.Write(Addresses.CurrentMusicData, currentLevelSongStartOffset);
-    #                 if (currentLevelSongTimestamp < currentLevelSongStartOffset || currentLevelSongStartOffset + 60 > currentLevelSongStartOffset + currentLevelSongLength)
-    #                 {
-    #                     Memory.Write(Addresses.CurrentMusicData + 4, currentLevelSongStartOffset);
-    #                 }
-    #                 Memory.Write(Addresses.CurrentMusicData + 8, currentLevelSongStartOffset + currentLevelSongLength);
-    #                 Memory.Write(Addresses.CurrentMusicData + 12, currentLevelSongChannel);
-    #                 Memory.WriteByte(Addresses.CurrentMusicStatus, (byte)currentLevelSongChannel);
-    #             }
-    #         }
+        music_changes = ctx.slot_data["options"]["main_level_music_array_changes"]
+        music_values_changed = False
+        for levelID in music_changes.keys():
+            song = int.from_bytes([main_level_songs[int(levelID)]], "little")
+            if song != music_changes[levelID]:
+                musicChangeWrites += [(RAM.MainLevelMusicArray + int(levelID), music_changes[levelID].to_bytes(1, "little"), "MainRAM")]
+                music_values_changed = True
+        if music_values_changed:
+            if str(current_level) in music_changes.keys():
+                new_song_id = int(music_changes[str(current_level)])
+                current_level_song_start_offset = 0x15f90 + int.from_bytes(full_music_array[8 * new_song_id:8 * new_song_id + 4], "little", signed=False)
+                current_level_song_timestamp = int.from_bytes(current_music_data[4:8], "little", signed=False)
+                current_level_song_length = int.from_bytes(full_music_array[4 + 8 * new_song_id:6 + 8 * new_song_id], "little", signed=False)
+                current_level_song_channel = int.from_bytes(full_music_array[6 + 8 * new_song_id: 8 + 8 * new_song_id], "little", signed=False)
+                musicChangeWrites += [(RAM.CurrentMusicData, current_level_song_start_offset.to_bytes(4, "little"), "MainRAM")]
+                if current_level_song_timestamp < current_level_song_start_offset or current_level_song_start_offset + 60 > current_level_song_start_offset + current_level_song_length:
+                    musicChangeWrites += [(RAM.CurrentMusicData + 4, current_level_song_start_offset.to_bytes(4, "little"), "MainRAM")]
+                musicChangeWrites += [(RAM.CurrentMusicData + 8, (current_level_song_start_offset + current_level_song_length).to_bytes(4, "little"), "MainRAM")]
+                musicChangeWrites += [(RAM.CurrentMusicData + 12, current_level_song_channel.to_bytes(4, "little"), "MainRAM")]
+                musicChangeWrites += [(RAM.CurrentMusicStatus, (1).to_bytes(1, "little"), "MainRAM")]
+
+        return musicChangeWrites
 
     def handleEloraDoorChanges(self, ctx, eloraDoorReads):
         currentLevel = eloraDoorReads[0]

--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -977,6 +977,14 @@ class Spyro2Client(BizHawkClient):
                 if len(colorChangeWrites) > 0:
                     await bizhawk.write(ctx.bizhawk_ctx, colorChangeWrites)
 
+                # ======== Musicsanity Handling ========
+                musicChangeReads = [
+
+                ]
+                musicChangeWrites = self.handleMusicChanges(ctx, musicChangeReads)
+                if len(musicChangeWrites) > 0:
+                    await bizhawk.write(ctx.bizhawk_ctx, musicChangeWrites)
+
                 # ======== Elora Text and Door Requirements ========
                 # Menuing out of Winter Tundra crashes the game on save file load,
                 # since the level ID doesn't change.
@@ -1578,6 +1586,48 @@ class Spyro2Client(BizHawkClient):
             if portalTextBlue != 0:
                 colorChangeWrites += [(RAM.PortalTextBlue, (0).to_bytes(1, "little"), "MainRAM")]
         return colorChangeWrites
+
+    def handleMusicChanges(self, ctx, musicChangeReads):
+        songs = musicChangeReads[0]
+
+        music_changes = ctx.slot_data["options"]["main_level_music_array_changes"]
+        for levelID in music_changes.keys():
+            pass
+
+        musicChangeWrites = []
+
+        #  bool musicValuesChanged = false;
+    #         if (mainLevelMusicChanges != null)
+    #         {
+    #             foreach (int levelID in mainLevelMusicChanges.Keys)
+    #             {
+    #                 byte song = Memory.ReadByte(Addresses.MainLevelMusicArray + (uint)levelID);
+    #                 if (song != (byte)mainLevelMusicChanges[levelID])
+    #                 {
+    #                     Memory.WriteByte(Addresses.MainLevelMusicArray + (uint)levelID, (byte)mainLevelMusicChanges[levelID]);
+    #                     musicValuesChanged = true;
+    #                 }
+    #             }
+    #         }
+    #         if (musicValuesChanged)
+    #         {
+    #             byte currentLevel = Memory.ReadByte(Addresses.CurrentLevelAddress);
+    #             if (mainLevelMusicChanges.ContainsKey((int)currentLevel))
+    #             {
+    #                 uint currentLevelSongStartOffset = 0x15f90 + Memory.ReadUInt(Addresses.FullMusicArray + (uint)(8 * mainLevelMusicChanges[(int)currentLevel]));
+    #                 uint currentLevelSongTimestamp = Memory.ReadUInt(Addresses.CurrentMusicData + 4);
+    #                 ushort currentLevelSongLength = Memory.ReadUShort(Addresses.FullMusicArray + (uint)(4 + 8 * mainLevelMusicChanges[(int)currentLevel]));
+    #                 short currentLevelSongChannel = Memory.ReadShort(Addresses.FullMusicArray + (uint)(6 + 8 * mainLevelMusicChanges[(int)currentLevel]));
+    #                 Memory.Write(Addresses.CurrentMusicData, currentLevelSongStartOffset);
+    #                 if (currentLevelSongTimestamp < currentLevelSongStartOffset || currentLevelSongStartOffset + 60 > currentLevelSongStartOffset + currentLevelSongLength)
+    #                 {
+    #                     Memory.Write(Addresses.CurrentMusicData + 4, currentLevelSongStartOffset);
+    #                 }
+    #                 Memory.Write(Addresses.CurrentMusicData + 8, currentLevelSongStartOffset + currentLevelSongLength);
+    #                 Memory.Write(Addresses.CurrentMusicData + 12, currentLevelSongChannel);
+    #                 Memory.WriteByte(Addresses.CurrentMusicStatus, (byte)currentLevelSongChannel);
+    #             }
+    #         }
 
     def handleEloraDoorChanges(self, ctx, eloraDoorReads):
         currentLevel = eloraDoorReads[0]

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -81,6 +81,13 @@ class RandomizeGemColorOptions:
     RANDOM = 2
     TRUE_RANDOM = 3
 
+class MusicsanityOptions:
+    OFF = 0
+    LIKE_WITH_LIKE_NO_MINIGAMES = 1
+    LIKE_WITH_LIKE = 2
+    FULL_NO_MINIGAMES = 3
+    FULL = 4
+
 
 class GoalOption(Choice):
     """Choose the completion goal.
@@ -555,6 +562,26 @@ class GemColor(Choice):
     option_random_choice = RandomizeGemColorOptions.RANDOM
     option_true_random = RandomizeGemColorOptions.TRUE_RANDOM
 
+class Musicsanity(Choice):
+    """Shuffles most of the music in game.
+    Off: No changes.
+    Like With Like: Music is shuffled within its type:
+        Homeworld, Normal Level, Boss.
+    Full: Music is shuffled regardless of type.
+    """
+    display_name = "Musicsanity"
+    default = MusicsanityOptions.OFF
+    option_off = MusicsanityOptions.OFF
+    option_like_with_like = MusicsanityOptions.LIKE_WITH_LIKE
+    option_full = MusicsanityOptions.FULL
+
+class StreamerMusic(Toggle):
+    """Streaming platforms sometimes mute VODs with the Autumn Plains
+    or Winter Tundrea homeworld music.
+    Replaces these with Summer Forest.
+    """
+    display_name = "Streamer-Friendly Music"
+
 @dataclass
 class Spyro2Option(PerGameCommonOptions):
     goal: GoalOption
@@ -613,6 +640,8 @@ class Spyro2Option(PerGameCommonOptions):
     easy_gulp: EasyGulp
     portal_gem_collection_color: PortalAndGemCollectionColor
     gem_color: GemColor
+    musicsanity: Musicsanity
+    streamer_music: StreamerMusic
 
 
 # Group logic/trick options together, especially for the local WebHost.
@@ -699,7 +728,9 @@ spyro_options_groups = [
         "Cosmetics",
         [
             PortalAndGemCollectionColor,
-            GemColor
+            GemColor,
+            Musicsanity,
+            StreamerMusic
         ],
         True
     ),

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -14,7 +14,8 @@ from .Items import (Spyro2Item, Spyro2ItemCategory, item_dictionary, key_item_na
 from .Locations import (Spyro2Location, Spyro2LocationCategory, location_tables,
     location_dictionary, location_name_groups)
 from .Options import Spyro2Option, GoalOptions, GemsanityOptions, GemsanityLocationOptions, MoneybagsOptions, \
-    RandomizeGemColorOptions, LevelLockOptions, TrickDifficultyOptions, spyro_options_groups, AbilityOptions, GemsanityRewardOptions
+    RandomizeGemColorOptions, LevelLockOptions, TrickDifficultyOptions, spyro_options_groups, AbilityOptions, \
+    GemsanityRewardOptions, MusicsanityOptions
 from .Logic import Logic, BaseLogic, EasyLogic, MediumLogic, CustomLogic
 from .Rules import get_level_rules
 from .Client import Spyro2Client
@@ -58,7 +59,8 @@ class Spyro2World(World):
     data_version = 0
     base_id = 1230000
     enabled_location_categories: Set[Spyro2LocationCategory]
-    required_client_version = (0, 5, 0)
+    # Effectively, minimum version of AP required.
+    required_client_version = (0, 6, 1)
     # TODO: Remember to update this!
     ap_world_version = "2.0.1"
     item_name_to_id = Spyro2Item.get_name_to_id()
@@ -681,6 +683,45 @@ class Spyro2World(World):
                 [self.random.randint(0, 16777216), self.random.randint(0, 16777216)],
             ]
 
+        main_level_music_changes = {}
+        music_array_changes = {}
+        if self.options.musicsanity.value != MusicsanityOptions.OFF:
+            homeworld_music = {0: 0}
+            if self.options.streamer_music.value:
+                homeworld_music[9] = 0
+                homeworld_music[21] = 0
+            else:
+                homeworld_music[9] = 11
+                homeworld_music[21] = 29
+            boss_music = {8: 10, 20: 28, 28: 37}
+            level_music = {1: 1, 2: 2, 3: 4, 4: 6, 5: 7, 6: 8, 7: 9, 10: 12, 11: 16, 12: 18, 13: 20, 14: 21, 15: 22,
+                           16: 23, 17: 24, 18: 2, 19: 27, 22: 30, 23: 31, 24: 33, 25: 34, 26: 35, 27: 36}
+            # minigame_music = {3: 3, 5: 5, 13: 13, 14: 14, 15: 15, 17: 17, 19: 19, 25: 25, 26: 26, 32: 32}
+            if self.options.musicsanity.value in [MusicsanityOptions.LIKE_WITH_LIKE]:
+                homeworld_values = [x for x in homeworld_music.values()]
+                boss_values = [x for x in boss_music.values()]
+                level_values = [x for x in level_music.values()]
+                self.random.shuffle(homeworld_values)
+                self.random.shuffle(boss_values)
+                self.random.shuffle(level_values)
+                for key in homeworld_music.keys():
+                    main_level_music_changes[key] = homeworld_values.pop(0)
+                for key in boss_music.keys():
+                    main_level_music_changes[key] = boss_values.pop(0)
+                for key in level_music.keys():
+                    main_level_music_changes[key] = level_values.pop(0)
+            else:
+                all_music = homeworld_music
+                all_music.update(boss_music)
+                all_music.update(level_music)
+                all_music_values = [x for x in all_music.values()]
+                self.random.shuffle(all_music_values)
+                for key in all_music.keys():
+                    main_level_music_changes[key] = all_music_values.pop(0)
+        elif self.options.streamer_music.value:
+            main_level_music_changes[9] = 0
+            main_level_music_changes[21] = 0
+
         slot_data = {
             "options": {
                 "goal": self.options.goal.value,
@@ -745,6 +786,10 @@ class Spyro2World(World):
                 "gold_gem_color": colors[3][1],
                 "pink_gem_shadow_color": colors[4][0],
                 "pink_gem_color": colors[4][1],
+                "musicsanity": self.options.musicsanity.value,
+                "streamer_music": self.options.streamer_music.value,
+                "main_level_music_array_changes": main_level_music_changes,
+                "music_array_changes": music_array_changes
             },
             "gemsanity_ids": gemsanity_locations,
             "level_orb_requirements": self.level_orb_requirements,

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -263,6 +263,11 @@ namespace S2AP
         public const int WTDoorGemBit = 7;
         public const uint WTWarpAddress = 0x6470a;
 
+        public const uint MainLevelMusicArray = 0x60140;
+        public const uint FullMusicArray = 0x64de4;
+        public const uint CurrentMusicData = 0x68320;
+        public const uint CurrentMusicStatus = 0x682f4;
+
         // ROM patching
         public const uint RomDialogueOrbCount = 0x3ec0c;
         public static readonly byte[] OrbCountCode = [0x2c, 0x70, 0x22, 0xac];

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -1506,7 +1506,7 @@ public partial class App : Application
                 }
                 Memory.Write(Addresses.CurrentMusicData + 8, currentLevelSongStartOffset + currentLevelSongLength);
                 Memory.Write(Addresses.CurrentMusicData + 12, currentLevelSongChannel);
-                Memory.WriteByte(Addresses.CurrentMusicStatus, (byte)currentLevelSongChannel);
+                Memory.WriteByte(Addresses.CurrentMusicStatus, (byte)1);
             }
         }
         if (

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -1430,6 +1430,7 @@ public partial class App : Application
                 }
             }
         }
+        // Cosmetics
         Memory.Write(Addresses.RedGemShadow, int.Parse(Client.Options?.GetValueOrDefault("red_gem_shadow_color", "0").ToString()));
         Memory.Write(Addresses.RedGemColor, int.Parse(Client.Options?.GetValueOrDefault("red_gem_color", "0").ToString()));
         Memory.Write(Addresses.GreenGemShadow, int.Parse(Client.Options?.GetValueOrDefault("green_gem_shadow_color", "0").ToString()));
@@ -1472,6 +1473,41 @@ public partial class App : Application
                 Memory.WriteByte(Addresses.PortalTextGreen, 64);
                 Memory.WriteByte(Addresses.PortalTextBlue, 0);
                 break;
+        }
+        bool musicValuesChanged = false;
+        Dictionary<int, int>? mainLevelMusicChanges = System.Text.Json.JsonSerializer.Deserialize<Dictionary<int, int>>(
+            Client.Options?.GetValueOrDefault("main_level_music_array_changes", new Dictionary<int, int>()).ToString()
+        );
+        if (mainLevelMusicChanges != null)
+        {
+            foreach (int levelID in mainLevelMusicChanges.Keys)
+            {
+                byte song = Memory.ReadByte(Addresses.MainLevelMusicArray + (uint)levelID);
+                if (song != (byte)mainLevelMusicChanges[levelID])
+                {
+                    Memory.WriteByte(Addresses.MainLevelMusicArray + (uint)levelID, (byte)mainLevelMusicChanges[levelID]);
+                    musicValuesChanged = true;
+                }
+            }
+        }
+        if (musicValuesChanged)
+        {
+            byte currentLevel = Memory.ReadByte(Addresses.CurrentLevelAddress);
+            if (mainLevelMusicChanges.ContainsKey((int)currentLevel))
+            {
+                uint currentLevelSongStartOffset = 0x15f90 + Memory.ReadUInt(Addresses.FullMusicArray + (uint)(8 * mainLevelMusicChanges[(int)currentLevel]));
+                uint currentLevelSongTimestamp = Memory.ReadUInt(Addresses.CurrentMusicData + 4);
+                ushort currentLevelSongLength = Memory.ReadUShort(Addresses.FullMusicArray + (uint)(4 + 8 * mainLevelMusicChanges[(int)currentLevel]));
+                short currentLevelSongChannel = Memory.ReadShort(Addresses.FullMusicArray + (uint)(6 + 8 * mainLevelMusicChanges[(int)currentLevel]));
+                Memory.Write(Addresses.CurrentMusicData, currentLevelSongStartOffset);
+                if (currentLevelSongTimestamp < currentLevelSongStartOffset || currentLevelSongStartOffset + 60 > currentLevelSongStartOffset + currentLevelSongLength)
+                {
+                    Memory.Write(Addresses.CurrentMusicData + 4, currentLevelSongStartOffset);
+                }
+                Memory.Write(Addresses.CurrentMusicData + 8, currentLevelSongStartOffset + currentLevelSongLength);
+                Memory.Write(Addresses.CurrentMusicData + 12, currentLevelSongChannel);
+                Memory.WriteByte(Addresses.CurrentMusicStatus, (byte)currentLevelSongChannel);
+            }
         }
         if (
             _cosmeticEffects.Count > 0 &&


### PR DESCRIPTION
Implements #144 

No logic changes, but tested the APWorld side by generating seeds with a number of options and confirming that the desired restrictions were maintained in the generated music arrays.

Tested clients by entering various levels, observing memory, and connecting to different seeds while in game to ensure the song switches over mid-level.