### PR TITLE
#12 - Add Sparx Powerups As Items

### DIFF
--- a/apworld/spyro2/Addresses.py
+++ b/apworld/spyro2/Addresses.py
@@ -1,3 +1,5 @@
+from .Enums import LevelInGameIDs
+
 class RAM:
     TotalTalismanAddress = 0x00067108
     TotalOrbAddress = 0x0006702c
@@ -251,6 +253,38 @@ class RAM:
     ]
     ShadyHeadbashCheck = 0x7d6c0
     GulpDoubleDamage = 0x120c5e
+
+    # Sparx Abilities
+    SparxHorizontalRange = 0x61a90
+    SparxVerticalRange = 0x61a98
+    # List is formatted as [addressToChange, hasAbilityCode, lacksAbilityCode].
+    # hasAbilityCode is always lw v1, -0x7c60(v1)
+    # lacksAbilityCode is an unconditional jump to the block of code after the gem finder ability code.
+    SparxGemFinderLookup = {
+        LevelInGameIDs.SummerForest: [0x72308, 0x8c6383a0, 0x0801c919],
+        LevelInGameIDs.Glimmer: [0x72794, 0x8c6383a0, 0x0801ca3c],
+        LevelInGameIDs.IdolSprings: [0x735f8, 0x8c6383a0, 0x0801cdd5],
+        LevelInGameIDs.Colossus: [0x72824, 0x8c6383a0, 0x0801ca60],
+        LevelInGameIDs.Hurricos: [0x72034, 0x8c6383a0, 0x0801c863],
+        LevelInGameIDs.AquariaTowers: [0x72f8c, 0x8c6383a0, 0x0801cc36],
+        LevelInGameIDs.SunnyBeach: [0x73b54, 0x8c6383a0, 0x0801cf2b],
+        LevelInGameIDs.AutumnPlains: [0x72668, 0x8c6383a0, 0x0801c9f1],
+        LevelInGameIDs.SkelosBadlands: [0x71868, 0x8c6383a0, 0x0801c670],
+        LevelInGameIDs.CrystalGlacier: [0x72630, 0x8c6383a0, 0x0801c9e2],
+        LevelInGameIDs.BreezeHarbor: [0x73c4c, 0x8c6383a0, 0x0801cf69],
+        LevelInGameIDs.Zephyr: [0x72110, 0x8c6383a0, 0x0801c89a],
+        LevelInGameIDs.Scorch: [0x71d68, 0x8c6383a0, 0x0801c7b0],
+        LevelInGameIDs.ShadyOasis: [0x721f4, 0x8c6383a0, 0x0801c8d3],
+        LevelInGameIDs.MagmaCone: [0x738e0, 0x8c6383a0, 0x0801ce8e],
+        LevelInGameIDs.FractureHills: [0x758c4, 0x8c6383a0, 0x0801d688],
+        LevelInGameIDs.WinterTundra: [0x725d8, 0x8c6383a0, 0x0801c9cd],
+        LevelInGameIDs.MysticMarsh: [0x7366c, 0x8c6383a0, 0x0801cdf2],
+        LevelInGameIDs.CloudTemples: [0x70e48, 0x8c6383a0, 0x0801c3e8],
+        LevelInGameIDs.RoboticaFarms: [0x7277c, 0x8c6383a0, 0x0801ca35],
+        LevelInGameIDs.Metropolis: [0x73eb8, 0x8c6383a0, 0x0801d005],
+    }
+    NearestGem = 0x61ab0
+    MaxHealth = 0x61a8c
 
     # Used to verify game is correct
     GuidebookText = 0x00010308

--- a/apworld/spyro2/Client.py
+++ b/apworld/spyro2/Client.py
@@ -246,7 +246,7 @@ class Spyro2Client(BizHawkClient):
 
     apworld_manifest = orjson.loads(pkgutil.get_data(__name__, "archipelago.json").decode("utf-8"))
     client_version = apworld_manifest["world_version"]
-    supported_versions = ["2.0.0", "2.0.0-rc", "2.0.1"]
+    supported_versions = ["2.0.1"]
 
     boolsyncprogress = False
     syncWaitConfirm = False
@@ -281,6 +281,7 @@ class Spyro2Client(BizHawkClient):
         self.isDestructive = False
         self.destructiveEnd = 0
         self.maxHealth = 3
+        self.extraHitPoint = 0
         self.currentLevel = None
         self.currentOrbs = 0
         self.currentGems = 0
@@ -289,6 +290,9 @@ class Spyro2Client(BizHawkClient):
         self.currentAPTalismans = 0
         self.currentTokens = 0
         self.currentSkillPoints = 0
+        self.lazySparxEnd = 0
+        self.extendedRange = False
+        self.gemFinder = False
 
     def initialize_client(self):
         self.messagequeue = []
@@ -315,6 +319,7 @@ class Spyro2Client(BizHawkClient):
         self.isDestructive = False
         self.destructiveEnd = 0
         self.maxHealth = 3
+        self.extraHitPoint = 0
         self.currentLevel = None
         self.currentOrbs = 0
         self.currentGems = 0
@@ -323,6 +328,9 @@ class Spyro2Client(BizHawkClient):
         self.currentAPTalismans = 0
         self.currentTokens = 0
         self.currentSkillPoints = 0
+        self.lazySparxEnd = 0
+        self.extendedRange = False
+        self.gemFinder = False
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         s2_identifier_ram_address: int = 0x9244
@@ -544,7 +552,12 @@ class Spyro2Client(BizHawkClient):
                 startingHealth = 1
             elif sparxOption != SparxUpgradeOptions.OFF:
                 startingHealth = 0
-            self.maxHealth = startingHealth
+            if sparxOption != SparxUpgradeOptions.TRUE_SPARXLESS:
+                # Ensure behavior matches the cheat code, and avoid rendering issues
+                # from more max health than intended.
+                if self.extraHitPoint > 1:
+                    self.extraHitPoint = 1
+            self.maxHealth = startingHealth + self.extraHitPoint
         try:
             if self.gotDatastorage:
                 # Last init to write the status
@@ -584,6 +597,10 @@ class Spyro2Client(BizHawkClient):
                 "collectiblesMask": (RAM.GemMaskAddress, 0x0006b000 - 0x0006ac84, "MainRAM"),
                 "lifeCount": (RAM.PlayerLives, 2, "MainRAM"),
                 "sparxHealth": (RAM.PlayerHealth, 1, "MainRAM"),
+                "maxHealth": (RAM.MaxHealth, 1, "MainRAM"),
+                "horizontalRange": (RAM.SparxHorizontalRange, 4, "MainRAM"),
+                "verticalRange": (RAM.SparxVerticalRange, 4, "MainRAM"),
+                "nearestGem": (RAM.NearestGem, 4, "MainRAM"),
                 "localGemIncrement": (RAM.localGemIncrementAddress, 4, "MainRAM"),
                 "globalGemIncrement": (RAM.globalGemIncrementAddress, 4, "MainRAM"),
                 "globalGemRespawnFix": (RAM.globalGemRespawnFixAddress, 4, "MainRAM"),
@@ -669,6 +686,10 @@ class Spyro2Client(BizHawkClient):
             collectiblesMask = readValues["collectiblesMask"]
             lifeCount = readValues["lifeCount"]
             sparxHealth = readValues["sparxHealth"]
+            maxHealth = readValues["maxHealth"]
+            horizontalRange = readValues["horizontalRange"]
+            verticalRange = readValues["verticalRange"]
+            nearestGem = readValues["nearestGem"]
             localGemIncrement = readValues["localGemIncrement"]
             globalGemIncrement = readValues["globalGemIncrement"]
             globalGemRespawnFix = readValues["globalGemRespawnFix"]
@@ -789,6 +810,12 @@ class Spyro2Client(BizHawkClient):
                         self.unlockedLevels.add(itemName)
                     elif itemName == "Progressive Sparx Health Upgrade":
                         sparxUpgrades += 1
+                    elif itemName == "Extra Hit Point":
+                        self.extraHitPoint = 1
+                    elif itemName == "Extended Sparx Range":
+                        self.extendedRange = True
+                    elif itemName == "Sparx Gem Finder":
+                        self.gemFinder = True
                     if increment < START_recv_index:
                         increment += 1
                     else:
@@ -814,6 +841,12 @@ class Spyro2Client(BizHawkClient):
                             else:
                                 self.destructiveEnd = time.time() + 15
                                 self.isDestructive = True
+                        elif itemName == "Lazy Sparx Trap":
+                            currentTime = time.time()
+                            if self.lazySparxEnd > currentTime:
+                                self.lazySparxEnd += 30
+                            else:
+                                self.lazySparxEnd = currentTime + 30
                         recv_index += 1
 
                 # Writes to memory if there is a new item, after the loop
@@ -853,7 +886,12 @@ class Spyro2Client(BizHawkClient):
                     startingHealth = 1
                 elif sparxOption != SparxUpgradeOptions.OFF:
                     startingHealth = 0
-                self.maxHealth = startingHealth + sparxUpgrades
+                if sparxOption != SparxUpgradeOptions.TRUE_SPARXLESS:
+                    # Ensure behavior matches the cheat code, and avoid rendering issues
+                    # from more max health than intended.
+                    if self.extraHitPoint > 1:
+                        self.extraHitPoint = 1
+                self.maxHealth = startingHealth + sparxUpgrades + self.extraHitPoint
 
                 if ctx.slot_data["options"]["enable_gemsanity"]:
                     itemsWrites += self.calculateCurrentGems(ctx, gemsanityItems, currentGems, totalGems)
@@ -1017,8 +1055,30 @@ class Spyro2Client(BizHawkClient):
                     await bizhawk.write(ctx.bizhawk_ctx, destructiveWrites)
 
                 # ======== Sparx Health Handling ========
-                sparxReads = [sparxHealth]
-                sparxWrites = self.handleSparxChanges(sparxReads)
+                currentLevelGemFinderLine = None
+                currentLevelGemFinderData = None
+                if ctx.slot_data["options"]["sparx_gem_finder"] and currentLevel in RAM.SparxGemFinderLookup.keys():
+                    readsDict = {
+                        "currentLevelGemFinderLine": (RAM.SparxGemFinderLookup[currentLevel][0], 4, "MainRAM"),
+                    }
+                    readTuples = [Value for Value in readsDict.values()]
+
+                    reads = await bizhawk.read(ctx.bizhawk_ctx, readTuples)
+                    reads = [int.from_bytes(reads[i], byteorder="little") for i, x in enumerate(reads)]
+                    readValues = dict(zip(readsDict.keys(), reads))
+                    currentLevelGemFinderLine = readValues["currentLevelGemFinderLine"]
+                    currentLevelGemFinderData = RAM.SparxGemFinderLookup[currentLevel]
+
+                sparxReads = [
+                    sparxHealth,
+                    maxHealth,
+                    horizontalRange,
+                    verticalRange,
+                    currentLevelGemFinderLine,
+                    currentLevelGemFinderData,
+                    nearestGem
+                ]
+                sparxWrites = self.handleSparxChanges(ctx, sparxReads)
                 if len(sparxWrites) > 0:
                     await bizhawk.write(ctx.bizhawk_ctx, sparxWrites)
 
@@ -1795,8 +1855,14 @@ class Spyro2Client(BizHawkClient):
 
         return destructiveWrites
 
-    def handleSparxChanges(self, sparxReads):
+    def handleSparxChanges(self, ctx, sparxReads):
         sparxHealth = sparxReads[0]
+        maxHealth = sparxReads[1]
+        horizontalRange = sparxReads[2]
+        verticalRange = sparxReads[3]
+        currentLevelGemFinderLine = sparxReads[4]
+        currentLevelGemFinderData = sparxReads[5]
+        nearestGem = sparxReads[6]
         currentTimestamp = time.time()
 
         sparxWrites = []
@@ -1819,9 +1885,45 @@ class Spyro2Client(BizHawkClient):
                 i = i + 1
         if 128 > sparxHealth > self.maxHealth:
             sparxHealth = self.maxHealth
-
         if sparxHealth != sparxReads[0]:
             sparxWrites += [(RAM.PlayerHealth, sparxHealth.to_bytes(1, "little"), "MainRAM")]
+        if self.maxHealth != maxHealth:
+            sparxWrites += [(RAM.MaxHealth, self.maxHealth.to_bytes(1, "little"), "MainRAM")]
+
+        if self.lazySparxEnd > time.time():
+            if horizontalRange != 1:
+                sparxWrites += [(RAM.SparxHorizontalRange, (1).to_bytes(4, "little"), "MainRAM")]
+            if verticalRange != 1:
+                sparxWrites += [(RAM.SparxVerticalRange, (1).to_bytes(4, "little"), "MainRAM")]
+        elif ctx.slot_data["options"]["extended_sparx_range"] == AbilityOptions.IN_POOL:
+            hasExtendedRange = self.extendedRange
+            newHorizontalRange = 2062
+            newVerticalRange = 640
+            if hasExtendedRange:
+                newHorizontalRange *= 2
+                newVerticalRange *= 2
+            if self.riptoDefeated:
+                # Counteract the in-game effect that doubles these when Ripto is defeated.
+                newHorizontalRange /= 2
+                newVerticalRange /= 2
+            if horizontalRange != newHorizontalRange:
+                sparxWrites += [(RAM.SparxHorizontalRange, newHorizontalRange.to_bytes(4, "little"), "MainRAM")]
+            if verticalRange != 640:
+                sparxWrites += [(RAM.SparxVerticalRange, newVerticalRange.to_bytes(4, "little"), "MainRAM")]
+        else:
+            if horizontalRange != 2062:
+                sparxWrites += [(RAM.SparxHorizontalRange, (1).to_bytes(4, "little"), "MainRAM")]
+            if verticalRange != 640:
+                sparxWrites += [(RAM.SparxVerticalRange, (1).to_bytes(4, "little"), "MainRAM")]
+
+        if ctx.slot_data["options"]["sparx_gem_finder"] != AbilityOptions.VANILLA:
+            if currentLevelGemFinderLine != None:
+                if self.gemFinder and currentLevelGemFinderLine != currentLevelGemFinderData[1]:
+                    sparxWrites += [(currentLevelGemFinderData[0], currentLevelGemFinderData[1].to_bytes(4, "little"), "MainRAM")]
+                elif not self.gemFinder and currentLevelGemFinderLine != currentLevelGemFinderData[2]:
+                    sparxWrites += [(currentLevelGemFinderData[0], currentLevelGemFinderData[2].to_bytes(4, "little"), "MainRAM")]
+                    if nearestGem != 0:
+                        sparxWrites += [(RAM.NearestGem, (0).to_bytes(4, "little"), "MainRAM")]
 
         return sparxWrites
 

--- a/apworld/spyro2/Items.py
+++ b/apworld/spyro2/Items.py
@@ -72,6 +72,10 @@ _all_items = [Spyro2ItemData(row[0], row[1], row[2]) for row in [
     ("Permanent Fireball Ability", 1021, Spyro2ItemCategory.ABILITY),
     ("Destructive Spyro", 1022, Spyro2ItemCategory.MISC),
     ("Normal Spyro", 1023, Spyro2ItemCategory.MISC),
+    ("Sparx Gem Finder", 1024, Spyro2ItemCategory.MISC),
+    ("Extended Sparx Range", 1025, Spyro2ItemCategory.MISC),
+    ("Extra Hit Point", 1026, Spyro2ItemCategory.MISC),
+    ("Lazy Sparx Trap", 1027, Spyro2ItemCategory.TRAP),
 
     ("Moneybags Unlock - Crystal Glacier Bridge", 3000, Spyro2ItemCategory.MONEYBAGS),
     ("Moneybags Unlock - Aquaria Towers Submarine", 3001, Spyro2ItemCategory.MONEYBAGS),
@@ -580,6 +584,16 @@ def BuildItemPool(world, count, options, locked_levels):
         item_pool.append(item_dictionary["Progressive Sparx Health Upgrade"])
         remaining_count = remaining_count - 1
 
+    if options.sparx_gem_finder == AbilityOptions.IN_POOL:
+        item_pool.append(item_dictionary["Sparx Gem Finder"])
+        remaining_count = remaining_count - 1
+    if options.extended_sparx_range == AbilityOptions.IN_POOL:
+        item_pool.append(item_dictionary["Extended Sparx Range"])
+        remaining_count = remaining_count - 1
+    if options.extra_hit_point == AbilityOptions.IN_POOL:
+        item_pool.append(item_dictionary["Extra Hit Point"])
+        remaining_count = remaining_count - 1
+
     if remaining_count < 0:
         raise OptionError(f"The options you have selected have {remaining_count * -1} more items than locations. You must choose options that add at least this many more locations.")
 
@@ -608,6 +622,8 @@ def BuildItemPool(world, count, options, locked_levels):
         elif item.name == 'Sparxless Trap' and options.enable_trap_sparxless:
             allowed_trap_items.append(item)
         elif item.name == 'Invisibility Trap' and options.enable_trap_invisibility:
+            allowed_trap_items.append(item)
+        elif item.name == 'Lazy Sparx Trap' and options.enable_trap_lazy_sparx:
             allowed_trap_items.append(item)
         elif item.name == "Normal Spyro" and (options.enable_filler_color_change or options.enable_filler_big_head_mode or len(allowed_misc_items) == 0):
             for i in range(0, 4):

--- a/apworld/spyro2/Options.py
+++ b/apworld/spyro2/Options.py
@@ -278,7 +278,7 @@ class GemsanityGemBundleSize(Choice):
      """Define the amount of gems awarded by each Gem Bundle item.
      Determines how many items are added to the item pool.
      Determines how many gem locations are randomly selected if
-         Gemsanity is set to Partial (sdds one location per bundle item).
+         Gemsanity is set to Partial (adds one location per bundle item).
      WARNING: Selecting an option smaller than 25 requires the host to
          edit allow_full_gemsanity in their yaml file.
      Default (50):adds 8 Gem Bundles per Level to the Item Pool (168 Total)
@@ -367,6 +367,10 @@ class EnableTrapInvisible(Toggle):
     Duckstation must be run in Interpreter mode for this to have any effect."""
     display_name = "Enable Invisibility Trap"
 
+class EnableTrapLazySparx(Toggle):
+    """Adds making Sparx refuse to pick up gems for 30 seconds to the item pool."""
+    display_name = "Enable Lazy Sparx Trap"
+
 class EnableTrapRemappedController(Toggle):
     """Allows filler items to "remap" your controller briefly.
     Duckstation must be run in Interpreter mode for this to have any effect."""
@@ -428,6 +432,36 @@ class FireballAbility(Choice):
     option_in_pool = AbilityOptions.IN_POOL
     option_off = AbilityOptions.OFF
     option_start_with = AbilityOptions.START_WITH
+
+class SparxGemFinderAbility(Choice):
+    """Settings for Sparx's gem finder ability.
+    Vanilla - Holding L1+R1+R2 has Sparx point to the nearest gem.
+        Beating Ripto makes the effect permanent.
+    In Pool - Adds Sparx Gem Finder to the item pool.
+        Behaves like Vanilla once you find the item.
+    Off - Removes the ability for Sparx to point to gems."""
+    display_name = "Sparx Gem Finder"
+    default = AbilityOptions.VANILLA
+    option_vanilla = AbilityOptions.VANILLA
+    option_in_pool = AbilityOptions.IN_POOL
+    option_off = AbilityOptions.OFF
+
+class ExtendedSparxRangeAbility(Choice):
+    """Settings for Extended Sparx range.
+    Vanilla - Beating Ripto doubles Sparx's range.
+    In Pool - Adds Extended Sparx Range to the item pool.
+        This item doubles Sparx's range.
+        Beating Ripto has no effect on your range."""
+    display_name = "Extended Sparx Range"
+    default = AbilityOptions.VANILLA
+    option_vanilla = AbilityOptions.VANILLA
+    option_in_pool = AbilityOptions.IN_POOL
+
+class ExtraHitPoint(Toggle):
+    """Adds an extra hit point (equivalent to the in game cheat code)
+    to the item pool. This does not affect progressive health logic.
+    Has no effect when Progressive Sparx Health Upgrades are True Sparxless."""
+    display_name = "Extra Hit Point in Item Pool"
 
 class TrickDifficulty(Choice):
     """Determines which tricks, if any, are in logic.
@@ -594,10 +628,14 @@ class Spyro2Option(PerGameCommonOptions):
     enable_trap_damage_sparx: EnableTrapDamageSparx
     enable_trap_sparxless: EnableTrapSparxless
     enable_trap_invisibility: EnableTrapInvisible
+    enable_trap_lazy_sparx: EnableTrapLazySparx
     enable_progressive_sparx_health: EnableProgressiveSparxHealth
     enable_progressive_sparx_logic: ProgressiveSparxHealthLogic
     double_jump_ability: DoubleJumpAbility
     permanent_fireball_ability: FireballAbility
+    sparx_gem_finder: SparxGemFinderAbility
+    extended_sparx_range: ExtendedSparxRangeAbility
+    extra_hit_point: ExtraHitPoint
     trick_difficulty: TrickDifficulty
     custom_tricks: CustomTricks
     colossus_starting_goals: ColossusStartingGoals
@@ -664,7 +702,8 @@ spyro_options_groups = [
             TrapFillerPercent,
             EnableTrapDamageSparx,
             EnableTrapSparxless,
-            EnableTrapInvisible
+            EnableTrapInvisible,
+            EnableTrapLazySparx
         ],
         True
     ),
@@ -672,7 +711,10 @@ spyro_options_groups = [
         "Sparx Settings",
         [
             EnableProgressiveSparxHealth,
-            ProgressiveSparxHealthLogic
+            ProgressiveSparxHealthLogic,
+            SparxGemFinderAbility,
+            ExtendedSparxRangeAbility,
+            ExtraHitPoint
         ],
         True
     ),

--- a/apworld/spyro2/__init__.py
+++ b/apworld/spyro2/__init__.py
@@ -358,6 +358,7 @@ class Spyro2World(World):
                 name == "Dragon Shores Token" and self.options.goal.value == GoalOptions.TEN_TOKENS:
             item_classification = ItemClassification.progression
         elif item_dictionary[name].category in useful_categories or \
+                name in ["Extended Sparx Range", "Sparx Gem Finder", "Extra Hit Point"] or \
                 not self.options.enable_progressive_sparx_logic.value and name == 'Progressive Sparx Health Upgrade' or \
                 name in ["Double Jump Ability"] and self.options.trick_difficulty.value == TrickDifficultyOptions.OFF:
             item_classification = ItemClassification.useful
@@ -716,8 +717,12 @@ class Spyro2World(World):
                 "enable_trap_damage_sparx": self.options.enable_trap_damage_sparx.value,
                 "enable_trap_sparxless": self.options.enable_trap_sparxless.value,
                 "enable_trap_invisibility": self.options.enable_trap_invisibility.value,
+                "enable_trap_lazy_sparx": self.options.enable_trap_lazy_sparx.value,
                 "enable_progressive_sparx_health": self.options.enable_progressive_sparx_health.value,
                 "enable_progressive_sparx_logic": self.options.enable_progressive_sparx_logic.value,
+                "sparx_gem_finder": self.options.sparx_gem_finder.value,
+                "extended_sparx_range": self.options.extended_sparx_range.value,
+                "extra_hit_point": self.options.extra_hit_point.value,
                 "double_jump_ability": self.options.double_jump_ability.value,
                 "permanent_fireball_ability": self.options.permanent_fireball_ability.value,
                 "trick_difficulty": self.options.trick_difficulty.value,

--- a/source/S2AP/Addresses.cs
+++ b/source/S2AP/Addresses.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using static S2AP.Models.Enums;
+
 
 namespace S2AP
 {
@@ -249,6 +251,38 @@ namespace S2AP
         ];
         public static uint ShadyHeadbashCheck = 0x7d6c0;
         public static uint GulpDoubleDamage = 0x120c5e;
+
+        public static uint SparxHorizontalRange = 0x61a90;
+        public static uint SparxVerticalRange = 0x61a98;
+        // List is formatted as [ addressToChange, hasAbilityCode, lacksAbilityCode ].
+        // hasAbilityCode is always lw v1, -0x7c60(v1)
+        // lacksAbilityCode is an unconditional jump to the block of code after the gem finder ability code.
+        public static readonly Dictionary<LevelInGameIDs, List<uint>> SparxGemFinderLookup = new Dictionary<LevelInGameIDs, List<uint>>()
+        {
+            { LevelInGameIDs.SummerForest, [0x72308, 0x8c6383a0, 0x0801c919] },
+            { LevelInGameIDs.Glimmer, [0x72794, 0x8c6383a0, 0x0801ca3c] },
+            { LevelInGameIDs.IdolSprings, [0x735f8, 0x8c6383a0, 0x0801cdd5] },
+            { LevelInGameIDs.Colossus, [0x72824, 0x8c6383a0, 0x0801ca60] },
+            { LevelInGameIDs.Hurricos, [0x72034, 0x8c6383a0, 0x0801c863] },
+            { LevelInGameIDs.AquariaTowers, [0x72f8c, 0x8c6383a0, 0x0801cc36] },
+            { LevelInGameIDs.SunnyBeach, [0x73b54, 0x8c6383a0, 0x0801cf2b] },
+            { LevelInGameIDs.AutumnPlains, [0x72668, 0x8c6383a0, 0x0801c9f1] },
+            { LevelInGameIDs.SkelosBadlands, [0x71868, 0x8c6383a0, 0x0801c670] },
+            { LevelInGameIDs.CrystalGlacier, [0x72630, 0x8c6383a0, 0x0801c9e2] },
+            { LevelInGameIDs.BreezeHarbor, [0x73c4c, 0x8c6383a0, 0x0801cf69] },
+            { LevelInGameIDs.Zephyr, [0x72110, 0x8c6383a0, 0x0801c89a] },
+            { LevelInGameIDs.Scorch, [0x71d68, 0x8c6383a0, 0x0801c7b0] },
+            { LevelInGameIDs.ShadyOasis, [0x721f4, 0x8c6383a0, 0x0801c8d3] },
+            { LevelInGameIDs.MagmaCone, [0x738e0, 0x8c6383a0, 0x0801ce8e] },
+            { LevelInGameIDs.FractureHills, [0x758c4, 0x8c6383a0, 0x0801d688] },
+            { LevelInGameIDs.WinterTundra, [0x725d8, 0x8c6383a0, 0x0801c9cd] },
+            { LevelInGameIDs.MysticMarsh, [0x7366c, 0x8c6383a0, 0x0801cdf2] },
+            { LevelInGameIDs.CloudTemples, [0x70e48, 0x8c6383a0, 0x0801c3e8] },
+            { LevelInGameIDs.RoboticaFarms, [0x7277c, 0x8c6383a0, 0x0801ca35] },
+            { LevelInGameIDs.Metropolis, [0x73eb8, 0x8c6383a0, 0x0801d005] },
+        };
+        public static uint NearestGem = 0x61ab0;
+        public static uint MaxHealth = 0x61a8c;
 
         public const uint GuidebookText = 0x00010308;
 

--- a/source/S2AP/App.axaml.cs
+++ b/source/S2AP/App.axaml.cs
@@ -51,10 +51,10 @@ public partial class App : Application
     private static bool _hasSubmittedGoal { get; set; }
     private static bool _useQuietHints { get; set; }
     private static int _unlockedLevels { get; set; }
-    private static Timer _sparxTimer { get; set; }
     private static Timer _loadGameTimer { get; set; }
     private static Timer _abilitiesTimer { get; set; }
     private static Timer _cosmeticsTimer { get; set; }
+    private static long _lazySparxEnd { get; set; }
     private static MoneybagsOptions _moneybagsOption { get; set; }
     private static PortalTextColor _portalTextColor { get; set; }
     private static LevelInGameIDs _previousLevel { get; set; }
@@ -648,6 +648,20 @@ public partial class App : Application
                         Memory.Write(Addresses.InvisibleAddress2, (short)0);
                     });
                     break;
+                case "Lazy Sparx Trap":
+                    await Task.Run(async () =>
+                    {
+                        long currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                        if (currentTimestamp > _lazySparxEnd)
+                        {
+                            _lazySparxEnd = currentTimestamp + 30;
+                        }
+                        else
+                        {
+                            _lazySparxEnd = _lazySparxEnd + 30;
+                        }
+                    });
+                    break;
                 case "Destructive Spyro":
                     await Task.Run(async () =>
                     {
@@ -930,6 +944,7 @@ public partial class App : Application
             HandleMoneybagsUnlocks();
             HandleInnerWTWarpAccess();
             CheckGoalCondition();
+            HandleSparxAbilities();
             byte lifeCount = Memory.ReadByte(Addresses.PlayerLives);
             AbilityOptions doubleJumpOption = (AbilityOptions)int.Parse(Client.Options?.GetValueOrDefault("double_jump_ability", "0").ToString());
             int hasDoubleJumpItem = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Double Jump Ability").Count() ?? 0);
@@ -1336,36 +1351,6 @@ public partial class App : Application
     }
     
     /**
-     * Handles the Sparx health upgrades within the game loop.
-     */
-    private static async void HandleMaxSparxHealth(object source, ElapsedEventArgs e)
-    {
-        if (!Helpers.IsInGame() || Client.ItemState == null || Client.CurrentSession == null)
-        {
-            return;
-        }
-        byte currentHealth = Memory.ReadByte(Addresses.PlayerHealth);
-        // Doing these checks trades efficency for correctness.
-        // We could probably do this check only upon connecting or receiving
-        // a health upgrade, but this is guaranteed to be correct.
-        ProgressiveSparxHealthOptions sparxOption = (ProgressiveSparxHealthOptions)int.Parse(Client.Options?.GetValueOrDefault("enable_progressive_sparx_health", "0").ToString());
-        byte maxHealth = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Progressive Sparx Health Upgrade").Count() ?? 0);
-        if (sparxOption == ProgressiveSparxHealthOptions.Blue)
-        {
-            maxHealth += 2;
-        }
-        else if (sparxOption == ProgressiveSparxHealthOptions.Green)
-        {
-            maxHealth += 1;
-        }
-        // Don't adjust negative health, which breaks deathlink.
-        if (currentHealth <= 128 && currentHealth > maxHealth)
-        {
-            Memory.WriteByte(Addresses.PlayerHealth, maxHealth);
-        }
-    }
-    
-    /**
      * Changes Spyro's color and big head mode, if there are any queued effects.
      * 
      * Also handles gem cosmetics and level lock options, which would be better moved elsewhere.
@@ -1740,7 +1725,109 @@ public partial class App : Application
             }
         }
     }
-    
+
+    /**
+     * Handles Spyro 3-style Sparx abilities like gem finder, as well as max health.
+     */
+    private static void HandleSparxAbilities()
+    {
+        if (!Helpers.IsInGame() || Client.ItemState == null || Client.CurrentSession == null)
+        {
+            return;
+        }
+        GameStatus gameStatus = (GameStatus)Memory.ReadByte(Addresses.GameStatus);
+        if (gameStatus == GameStatus.Paused || gameStatus == GameStatus.LoadingWorld || gameStatus == GameStatus.Cutscene)
+        {
+            return;
+        }
+        byte currentHealth = Memory.ReadByte(Addresses.PlayerHealth);
+        // Doing these checks trades efficency for correctness.
+        // We could probably do this check only upon connecting or receiving
+        // a health upgrade, but this is guaranteed to be correct.
+        ProgressiveSparxHealthOptions sparxOption = (ProgressiveSparxHealthOptions)int.Parse(Client.Options?.GetValueOrDefault("enable_progressive_sparx_health", "0").ToString());
+        byte maxHealth = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Progressive Sparx Health Upgrade").Count() ?? 0);
+        byte extraHitPoint = (byte)(Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Extra Hit Point").Count() ?? 0);
+        if (sparxOption == ProgressiveSparxHealthOptions.Off)
+        {
+            maxHealth = 3;  // Ignore Progressive Sparx Health Upgrade items when the setting is off.
+        }
+        else if (sparxOption == ProgressiveSparxHealthOptions.Blue)
+        {
+            maxHealth += 2;
+        }
+        else if (sparxOption == ProgressiveSparxHealthOptions.Green)
+        {
+            maxHealth += 1;
+        }
+        if (sparxOption != ProgressiveSparxHealthOptions.TrueSparxless)
+        {
+            // Ensure behavior matches the cheat code, and avoid rendering issues from more max health than intended.
+            if (extraHitPoint > 1)
+            {
+                extraHitPoint = 1;
+            }
+            maxHealth += extraHitPoint;
+        }
+        // Unlike Spyro 3, the player respawns at maxHealth, so this handles most cases, except immediately on connect.
+        Memory.WriteByte(Addresses.MaxHealth, maxHealth);
+        // Don't adjust negative health, which breaks deathlink.
+        if (currentHealth <= 128 && currentHealth > maxHealth)
+        {
+            Memory.WriteByte(Addresses.PlayerHealth, maxHealth);
+        }
+
+        AbilityOptions sparxGemFinder = (AbilityOptions)int.Parse(Client.Options?.GetValueOrDefault("sparx_gem_finder", "0").ToString());
+        AbilityOptions extendedSparxRange = (AbilityOptions)int.Parse(Client.Options?.GetValueOrDefault("extended_sparx_range", "0").ToString());
+
+        if (sparxGemFinder != AbilityOptions.Vanilla)
+        {
+            LevelInGameIDs currentLevel = (LevelInGameIDs)Memory.ReadByte(Addresses.CurrentLevelAddress);
+            if (Addresses.SparxGemFinderLookup.ContainsKey(currentLevel))
+            {
+                bool hasGemFinder = (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Sparx Gem Finder").Count() ?? 0) > 0;
+                if (hasGemFinder)
+                {
+                    Memory.Write(Addresses.SparxGemFinderLookup[currentLevel][0], Addresses.SparxGemFinderLookup[currentLevel][1]);
+                }
+                else
+                {
+                    Memory.Write(Addresses.SparxGemFinderLookup[currentLevel][0], Addresses.SparxGemFinderLookup[currentLevel][2]);
+                    Memory.Write(Addresses.NearestGem, 0);  // Sparx can get locked pointing at nonexistant objects if this isn't forced to be null.
+                }
+            }
+        }
+
+        if (_lazySparxEnd > DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        {
+            Memory.Write(Addresses.SparxHorizontalRange, 1);
+            Memory.Write(Addresses.SparxVerticalRange, 1);
+        }
+        else if (extendedSparxRange == AbilityOptions.InPool)
+        {
+            bool isRiptoDefeated = (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Ripto Defeated").Count() ?? 0) > 0;
+            bool hasExtendedRange = (Client.CurrentSession?.Items?.AllItemsReceived?.Where(x => x.ItemName == "Extended Sparx Range").Count() ?? 0) > 0;
+            int horizontalRange = 2062;
+            int verticalRange = 640;
+            if (hasExtendedRange)
+            {
+                horizontalRange *= 2;
+                verticalRange *= 2;
+            }
+            if (isRiptoDefeated)
+            {
+                // Counteract the in-game effect that doubles these when Ripto is defeated.
+                horizontalRange /= 2;
+                verticalRange /= 2;
+            }
+            Memory.Write(Addresses.SparxHorizontalRange, horizontalRange);
+            Memory.Write(Addresses.SparxVerticalRange, verticalRange);
+        } else
+        {
+            Memory.Write(Addresses.SparxHorizontalRange, 2062);
+            Memory.Write(Addresses.SparxVerticalRange, 640);
+        }
+    }
+
     /**
      * Turns off big head mode and also flat Spyro mode.
      */
@@ -2080,15 +2167,6 @@ public partial class App : Application
         _cosmeticsTimer.Interval = 5000;
         _cosmeticsTimer.Enabled = true;
 
-        ProgressiveSparxHealthOptions sparxOption = (ProgressiveSparxHealthOptions)int.Parse(Client.Options?.GetValueOrDefault("enable_progressive_sparx_health", "0").ToString());
-        if (sparxOption != ProgressiveSparxHealthOptions.Off)
-        {
-            _sparxTimer = new Timer();
-            _sparxTimer.Elapsed += new ElapsedEventHandler(HandleMaxSparxHealth);
-            _sparxTimer.Interval = 500;
-            _sparxTimer.Enabled = true;
-        }
-
         _moneybagsOption = (MoneybagsOptions)int.Parse(Client.Options?.GetValueOrDefault("moneybags_settings", "0").ToString());
         _portalTextColor = (PortalTextColor)int.Parse(Client.Options?.GetValueOrDefault("portal_gem_collection_color", "0").ToString());
 
@@ -2121,6 +2199,7 @@ public partial class App : Application
         _handleGemsanity = false;
         _unlockedLevels = 0;
         _requiredOrbs = 65;
+        _lazySparxEnd = 0;
 
         if (_deathLinkService != null)
         {
@@ -2141,11 +2220,6 @@ public partial class App : Application
         {
             _cosmeticsTimer.Enabled = false;
             _cosmeticsTimer = null;
-        }
-        if (_sparxTimer != null)
-        {
-            _sparxTimer.Enabled = false;
-            _sparxTimer = null;
         }
     }
 }


### PR DESCRIPTION
Implements #12 and also adds a Lazy Sparx Trap (for 30 seconds, Sparx won't collect gems) and fixes a typo in an option.

No logic changes.

Both clients tested, including some crashes fixed from the initial implementation.  Checked every level's gem finder code, since they're hardcoded.